### PR TITLE
Brand pivot FooterBlock

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@emotion/core": "^10.0.22",
     "@emotion/styled": "^10.0.23",
-    "@hedviginsurance/brand": "^3.0.1",
+    "@hedviginsurance/brand": "^3.0.3",
     "@hedviginsurance/cli": "^2.3.2",
     "@hedviginsurance/react-swipeable-views": "^0.12.20",
     "@hedviginsurance/web-survival-kit": "^1.7.0",

--- a/src/blocks/FooterBlockBrandPivot.tsx
+++ b/src/blocks/FooterBlockBrandPivot.tsx
@@ -1,0 +1,246 @@
+import styled from '@emotion/styled'
+import * as React from 'react'
+import {
+  ContentWrapper,
+  SectionWrapper,
+  TABLET_BP_DOWN,
+  TABLET_BP_UP,
+  SITE_MAX_WIDTH,
+  CONTENT_GUTTER,
+  CONTENT_GUTTER_MOBILE,
+  MOBILE_BP_UP,
+} from '../components/blockHelpers'
+import { ContextContainer } from '../components/containers/ContextContainer'
+import { GlobalStoryContainer } from '../storyblok/StoryContainer'
+import { getStoryblokLinkUrl } from '../utils/storyblok'
+import { BaseBlockProps } from './BaseBlockProps'
+import { colorsV3 } from '@hedviginsurance/brand'
+import { HedvigH } from '../components/icons/HedvigH'
+
+const BP_DOWN = '@media (max-width: 600px)'
+
+const FooterWrapper = styled('div')({
+  padding: `5rem 0`,
+
+  [MOBILE_BP_UP]: {
+    padding: `4.25rem 0 12rem`,
+  },
+})
+
+const IconWrapper = styled('div')({
+  display: 'flex',
+  justifyContent: 'flex-end',
+  margin: '0 auto 3.125rem',
+  paddingLeft: CONTENT_GUTTER_MOBILE,
+  paddingRight: CONTENT_GUTTER_MOBILE,
+
+  [MOBILE_BP_UP]: {
+    paddingLeft: CONTENT_GUTTER,
+    paddingRight: CONTENT_GUTTER,
+  },
+
+  ...SITE_MAX_WIDTH,
+})
+
+const FooterInnerWrapper = styled('footer')({
+  display: 'flex',
+  flexDirection: 'row',
+  justifyContent: 'center',
+  [TABLET_BP_DOWN]: {
+    flexDirection: 'column',
+  },
+})
+
+const LinkTextWrapper = styled('div')({
+  display: 'flex',
+  flexDirection: 'column',
+})
+
+const LinksColumnsWrapper = styled('nav')({
+  display: 'flex',
+  flexDirection: 'row',
+  marginTop: '2rem',
+  [TABLET_BP_UP]: {
+    marginTop: '0',
+    marginBottom: '5rem',
+    justifyContent: 'center',
+  },
+  [BP_DOWN]: {
+    flexWrap: 'wrap',
+  },
+})
+
+const ColumnHeader = styled('div')({
+  paddingBottom: '1.5rem',
+  fontSize: '1.125rem',
+  color: colorsV3.white, // TODO: Change to new color
+  [TABLET_BP_UP]: {
+    paddingBottom: '2rem',
+    fontSize: '1.5rem',
+  },
+})
+
+const LinkColumn = styled('div')({
+  '&:not(:last-of-type)': {
+    paddingRight: '7rem',
+    paddingBottom: '.5rem',
+    '@media(max-width:1100px)': {
+      paddingRight: '4rem',
+    },
+    [BP_DOWN]: {
+      width: '50%',
+      paddingRight: 0,
+      paddingBottom: '2rem',
+    },
+  },
+  '&:last-of-type': {
+    [BP_DOWN]: {
+      paddingBottom: '2rem',
+    },
+  },
+})
+const Link = styled('a')({
+  display: 'block',
+  color: 'inherit',
+  fontSize: '0.875rem',
+  textDecoration: 'none',
+  marginBottom: '14px',
+})
+
+const FooterFooter = styled('div')({
+  opacity: 0.28,
+  fontSize: '0.9rem',
+  marginTop: '2rem',
+})
+
+type FooterBlockProps = BaseBlockProps
+
+export const FooterBlockBrandPivot: React.FunctionComponent<FooterBlockProps> = ({
+  color,
+  extra_styling,
+}) => (
+  <GlobalStoryContainer>
+    {({ globalStory }) => (
+      <ContextContainer>
+        {(context) => (
+          <SectionWrapper
+            brandPivot
+            colorComponent={color}
+            size="none"
+            extraStyling={extra_styling}
+          >
+            <FooterWrapper>
+              <IconWrapper>
+                <HedvigH size={48} />
+              </IconWrapper>
+              <ContentWrapper>
+                <FooterInnerWrapper>
+                  <LinkTextWrapper>
+                    {globalStory.content.get_started &&
+                    globalStory.content.get_started.length &&
+                    globalStory.content.company &&
+                    globalStory.content.company.length &&
+                    globalStory.content.legal &&
+                    globalStory.content.legal.length &&
+                    globalStory.content.social &&
+                    globalStory.content.social.length ? (
+                      <LinksColumnsWrapper>
+                        <LinkColumn>
+                          <ColumnHeader>
+                            {context.lang === 'sv'
+                              ? 'Hemförsäkring'
+                              : 'Home insurance'}
+                          </ColumnHeader>
+                          {(globalStory.content.get_started ?? []).map(
+                            (link) => (
+                              <Link
+                                key={link._uid}
+                                href={getStoryblokLinkUrl(link.link)}
+                              >
+                                {link.label}
+                              </Link>
+                            ),
+                          )}
+                        </LinkColumn>
+                        <LinkColumn>
+                          <ColumnHeader>
+                            {context.lang === 'sv' ? 'Hedvig' : 'Company'}
+                          </ColumnHeader>
+                          {(globalStory.content.company ?? []).map((link) => (
+                            <Link
+                              key={link._uid}
+                              href={getStoryblokLinkUrl(link.link)}
+                            >
+                              {link.label}
+                            </Link>
+                          ))}
+                        </LinkColumn>
+                        <LinkColumn>
+                          <ColumnHeader>{'Legal'}</ColumnHeader>
+                          {(globalStory.content.legal ?? []).map((link) => (
+                            <Link
+                              key={link._uid}
+                              href={getStoryblokLinkUrl(link.link)}
+                            >
+                              {link.label}
+                            </Link>
+                          ))}
+                        </LinkColumn>
+                        <LinkColumn>
+                          <ColumnHeader>{'Social'}</ColumnHeader>
+                          {(globalStory.content.social ?? []).map((link) => (
+                            <Link
+                              key={link._uid}
+                              href={getStoryblokLinkUrl(link.link)}
+                            >
+                              {link.label}
+                            </Link>
+                          ))}
+                        </LinkColumn>
+                      </LinksColumnsWrapper>
+                    ) : (
+                      <LinksColumnsWrapper>
+                        <LinkColumn>
+                          {(globalStory.content.footer_menu_items_1 ?? []).map(
+                            (link) => (
+                              <Link
+                                key={link._uid}
+                                href={getStoryblokLinkUrl(link.link)}
+                              >
+                                {link.label}
+                              </Link>
+                            ),
+                          )}
+                        </LinkColumn>
+                        <LinkColumn>
+                          {(globalStory.content.footer_menu_items_2 ?? []).map(
+                            (link) => (
+                              <Link
+                                key={link._uid}
+                                href={getStoryblokLinkUrl(link.link)}
+                              >
+                                {link.label}
+                              </Link>
+                            ),
+                          )}
+                        </LinkColumn>
+                      </LinksColumnsWrapper>
+                    )}
+
+                    <FooterFooter
+                      dangerouslySetInnerHTML={{
+                        __html:
+                          globalStory.content.footer_paragraph &&
+                          globalStory.content.footer_paragraph.html,
+                      }}
+                    />
+                  </LinkTextWrapper>
+                </FooterInnerWrapper>
+              </ContentWrapper>
+            </FooterWrapper>
+          </SectionWrapper>
+        )}
+      </ContextContainer>
+    )}
+  </GlobalStoryContainer>
+)

--- a/src/blocks/FooterBlockBrandPivot.tsx
+++ b/src/blocks/FooterBlockBrandPivot.tsx
@@ -73,7 +73,7 @@ const LinksColumnsWrapper = styled('nav')({
 const ColumnHeader = styled('div')({
   paddingBottom: '1.5rem',
   fontSize: '1.125rem',
-  color: colorsV3.white, // TODO: Change to new color
+  color: colorsV3.gray500,
   [TABLET_BP_UP]: {
     paddingBottom: '2rem',
     fontSize: '1.5rem',

--- a/src/blocks/FooterBlockBrandPivot.tsx
+++ b/src/blocks/FooterBlockBrandPivot.tsx
@@ -136,14 +136,10 @@ export const FooterBlockBrandPivot: React.FunctionComponent<FooterBlockProps> = 
               <ContentWrapper>
                 <FooterInnerWrapper>
                   <LinkTextWrapper>
-                    {globalStory.content.get_started &&
-                    globalStory.content.get_started.length &&
-                    globalStory.content.company &&
-                    globalStory.content.company.length &&
-                    globalStory.content.legal &&
-                    globalStory.content.legal.length &&
-                    globalStory.content.social &&
-                    globalStory.content.social.length ? (
+                    {globalStory.content.get_started?.length &&
+                    globalStory.content.company?.length &&
+                    globalStory.content.legal?.length &&
+                    globalStory.content.social?.length ? (
                       <LinksColumnsWrapper>
                         <LinkColumn>
                           <ColumnHeader>
@@ -229,9 +225,7 @@ export const FooterBlockBrandPivot: React.FunctionComponent<FooterBlockProps> = 
 
                     <FooterFooter
                       dangerouslySetInnerHTML={{
-                        __html:
-                          globalStory.content.footer_paragraph &&
-                          globalStory.content.footer_paragraph.html,
+                        __html: globalStory.content.footer_paragraph?.html,
                       }}
                     />
                   </LinkTextWrapper>

--- a/src/blocks/FooterBlockBrandPivot.tsx
+++ b/src/blocks/FooterBlockBrandPivot.tsx
@@ -1,21 +1,21 @@
 import styled from '@emotion/styled'
+import { colorsV3 } from '@hedviginsurance/brand'
 import * as React from 'react'
 import {
-  ContentWrapper,
-  SectionWrapper,
-  TABLET_BP_DOWN,
-  TABLET_BP_UP,
-  SITE_MAX_WIDTH,
   CONTENT_GUTTER,
   CONTENT_GUTTER_MOBILE,
+  ContentWrapper,
   MOBILE_BP_UP,
+  SectionWrapper,
+  SITE_MAX_WIDTH,
+  TABLET_BP_DOWN,
+  TABLET_BP_UP,
 } from '../components/blockHelpers'
 import { ContextContainer } from '../components/containers/ContextContainer'
+import { HedvigH } from '../components/icons/HedvigH'
 import { GlobalStoryContainer } from '../storyblok/StoryContainer'
 import { getStoryblokLinkUrl } from '../utils/storyblok'
 import { BaseBlockProps } from './BaseBlockProps'
-import { colorsV3 } from '@hedviginsurance/brand'
-import { HedvigH } from '../components/icons/HedvigH'
 
 const BP_DOWN = '@media (max-width: 600px)'
 

--- a/src/blocks/index.tsx
+++ b/src/blocks/index.tsx
@@ -8,6 +8,7 @@ import { BulletPointBlock } from './BulletPointBlock'
 import { CardChecklistBulletPointBlock } from './CardChecklistBulletPointBlock'
 import { DownloadBlock } from './DownloadBlock'
 import { FooterBlock } from './FooterBlock'
+import { FooterBlockBrandPivot } from './FooterBlockBrandPivot'
 import { HeaderBlock } from './HeaderBlock'
 import { HeadlineBlock } from './HeadlineBlock'
 import { HeroVideoBlock } from './HeroVideoBlock'
@@ -52,6 +53,7 @@ const blockComponents = {
   trustpilot_block: TrustpilotBlock,
   spacer_block: SpacerBlock,
   footer_block: FooterBlock,
+  footer_block_brand_pivot: FooterBlockBrandPivot,
   card_checklist_bullet_point_block: CardChecklistBulletPointBlock,
   press_card_block: PressCardBlock,
 }

--- a/src/components/blockHelpers.tsx
+++ b/src/components/blockHelpers.tsx
@@ -199,7 +199,7 @@ export const getColorStyles = (
 export const getMinimalColorStyles = (
   color: minimalColorComponentColors,
   standardColor: string = colorsV3.white,
-  standardInverseColor: string = colorsV3.black,
+  standardInverseColor: string = colorsV3.gray900,
 ) =>
   match([
     ['standard', { background: standardColor, color: standardInverseColor }],

--- a/src/components/blockHelpers.tsx
+++ b/src/components/blockHelpers.tsx
@@ -22,6 +22,13 @@ export const TABLET_BP_DOWN = '@media (max-width: 840px)'
 export const TABLET_BP_UP = '@media (min-width: 801px)'
 export const GIANT_BP_UP = '@media (min-width: 1700px)'
 
+export const SITE_MAX_WIDTH = {
+  maxWidth: 1384,
+  [GIANT_BP_UP]: {
+    maxWidth: 1500, // TODO: Update this value when we have design for large screens
+  },
+}
+
 export const CONTENT_MAX_WIDTH = {
   maxWidth: 1200,
   [GIANT_BP_UP]: {

--- a/src/components/blockHelpers.tsx
+++ b/src/components/blockHelpers.tsx
@@ -1,6 +1,6 @@
 import { keyframes } from '@emotion/core'
 import styled from '@emotion/styled'
-import { colors, colorsV3 } from '@hedviginsurance/brand'
+import { colors, colorsV3, fonts } from '@hedviginsurance/brand'
 import { match } from 'matchly'
 import * as React from 'react'
 import { RouteComponentProps, withRouter } from 'react-router'
@@ -223,11 +223,13 @@ interface SectionProps {
   size?: SectionSize
   backgroundImage?: string
   extraStyling?: string
+  brandPivot?: boolean
 }
 const SectionWrapperComponentUnstyled = styled('section')<SectionProps>(
-  ({ colorComponent, size = 'lg' }) => ({
+  ({ colorComponent, size = 'lg', brandPivot }) => ({
     position: 'relative',
     transition: 'background 300ms',
+    fontFamily: brandPivot ? `${fonts.FAVORIT}, sans-serif` : undefined,
     ...getSectionSizeStyle(size),
     color:
       colorComponent?.plugin === 'hedvig_minimal_color_picker'

--- a/src/components/icons/HedvigH.tsx
+++ b/src/components/icons/HedvigH.tsx
@@ -1,0 +1,17 @@
+import styled from '@emotion/styled'
+import * as React from 'react'
+
+const Svg = styled('svg')({
+  fill: 'currentColor',
+})
+
+export const HedvigH: React.FunctionComponent<{ size: number }> = ({
+  size,
+}) => (
+  <Svg width={String(size)} height={String(size)} viewBox="0 0 300 300">
+    <g fill-rule="nonzero">
+      <path d="M150 0C67.157 0 0 67.157 0 150s67.157 150 150 150 150-67.157 150-150A150 150 0 00150 0zm0 279.59c-71.44 0-129.56-58.07-129.56-129.57C20.523 78.5 78.48 20.543 150 20.46c71.45 0 129.57 58.12 129.57 129.56-.077 71.528-58.042 129.493-129.57 129.57z" />
+      <path d="M194.33 139.8h-88.65V68.19H85.22v163.67h20.46v-71.61h88.65v71.61h20.46V68.19h-20.46z" />
+    </g>
+  </Svg>
+)

--- a/storyblok/components.json
+++ b/storyblok/components.json
@@ -800,6 +800,34 @@
       "component_group_uuid": null
     },
     {
+      "name": "footer_block_brand_pivot",
+      "display_name": "",
+      "schema": {
+        "color": {
+          "type": "custom",
+          "field_type": "hedvig-minimal-color-picker",
+          "options": [],
+          "default_value": "off-black-dark",
+          "pos": 0,
+          "display_name": ""
+        },
+        "extra_styling": {
+          "type": "textarea",
+          "pos": 1,
+          "description": "Raw CSS for this section Nb! Do NOT target classes directly, especially not ones that look like .css-g041i5! They are auto-generated and will change often, causing your changes to break."
+        }
+      },
+      "image": null,
+      "preview_field": null,
+      "is_root": false,
+      "preview_tmpl": null,
+      "is_nestable": true,
+      "all_presets": [],
+      "preset_id": null,
+      "real_name": "footer_block_brand_pivot",
+      "component_group_uuid": null
+    },
+    {
       "name": "global",
       "display_name": null,
       "schema": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -944,10 +944,10 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
-"@hedviginsurance/brand@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@hedviginsurance/brand/-/brand-3.0.1.tgz#25a5ec3d77a2d7306e9ec11cf87cf2c74dfa570e"
-  integrity sha512-PP3UaW9dQ7QpNa4B5tCR09zUIwCQwnJcvrmV8Sn6gjImQN1k2UZQhhjYSL8OE7TdBupj+NCuH1wR8Zyf1/sN3Q==
+"@hedviginsurance/brand@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@hedviginsurance/brand/-/brand-3.0.3.tgz#1792eb48f2e0f723b0088f4a0852342c2ef8c818"
+  integrity sha512-efAV2Tuuy+948dkPAt4md0sd9rtWtXkWjydQ8cG0V0jCNZbJrEtrUXAOSHBm8qKm7omhb5dBQ1QfRa8BOeb5eg==
 
 "@hedviginsurance/cli@^2.3.2":
   version "2.3.3"


### PR DESCRIPTION
`SectionWrapper` now has a `brandPivot` prop that changes the font-family:

Also bumped the brand package version that includes the update colors.

<img width="1480" alt="Screenshot 2020-03-06 at 10 56 24" src="https://user-images.githubusercontent.com/6661511/76073185-8426ed00-5f99-11ea-828b-a580958b1bc7.png">
