### PR TITLE
Fix cookie consent not unmounting

### DIFF
--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -72,7 +72,7 @@ export const CookieConsent: React.FC = () => {
     }
   }, [Cookies.get()?._hvcookie])
 
-  if (!isVisible && !isClosing) {
+  if (!isVisible) {
     return null
   }
 


### PR DESCRIPTION
This would not un mount when closing the cookie consent, only on reload when the cookie is already set.