### PR TITLE
Fix/hreflang

### DIFF
--- a/src/server/page.tsx
+++ b/src/server/page.tsx
@@ -136,7 +136,8 @@ export const getPageMiddleware = (
 
   // Redirect /* to /se/*
   if (!langFromPath && !ctx.query._storyblok) {
-    ctx.redirect(`/se${ctx.originalUrl}`)
+    const url = ctx.originalUrl === '/' ? '' : ctx.originalUrl
+    ctx.redirect(`/se${url}`)
     return
   }
 

--- a/src/server/utils/storyblok.ts
+++ b/src/server/utils/storyblok.ts
@@ -107,7 +107,7 @@ export const getLangFromPath = (path: string) => {
       return 'no-en'
     case /^\/en($|\/.*)/.test(path):
       return 'en'
-    case /^\/sv\/.*/.test(path):
+    case /^\/sv($|\/.*)/.test(path):
       return 'sv'
     default:
       return null

--- a/src/utils/meta.tsx
+++ b/src/utils/meta.tsx
@@ -11,7 +11,7 @@ interface Meta {
 }
 
 const getFullSlugFromStory = (story?: Story) =>
-  story && story.full_slug.replace(/\/?home$/, '').replace(/\/sv($|\/)/, '')
+  story && story.full_slug.replace(/\/?home$/, '').replace(/\/+$/, '')
 
 const getPageTitleFromStory = (story?: Story) => {
   if (!story) {


### PR DESCRIPTION
Address the following issues

- hreflang in `meta.tsx` for root gets a trailing slash and hence returns a 301 (/se/ -> /se)
- / redirects to /se/ and then to /se