### PR TITLE
Refactor/header

### DIFF
--- a/.storybook/decorators/themeDecorator.tsx
+++ b/.storybook/decorators/themeDecorator.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { Global } from '@emotion/core'
-import { globalStyles } from '../../src/components/GlobalStyles'
+import { globalStylesStorybook } from '../../src/components/GlobalStyles'
 
 export const themeDecorator = (story) => (
   <>
-    <Global styles={globalStyles} />
+    <Global styles={globalStylesStorybook} />
     {story()}
   </>
 )

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -2,6 +2,7 @@ import { addDecorator } from '@storybook/react'
 import { addParameters } from '@storybook/react'
 import { withPaddings } from 'storybook-addon-paddings'
 import { themeDecorator } from './decorators/themeDecorator'
+import { colorsV3 } from '@hedviginsurance/brand'
 
 // Add global decorators (added to all stories)
 addDecorator(withPaddings)
@@ -62,4 +63,11 @@ addParameters({
       ...customViewports,
     },
   },
+})
+
+addParameters({
+  backgrounds: [
+    { name: 'gray900', value: colorsV3.gray900 },
+    { name: 'gray100', value: colorsV3.gray100, default: true },
+  ],
 })

--- a/src/blocks/HeaderBlockBrandPivot/HeaderBlockBrandPivot.stories.tsx
+++ b/src/blocks/HeaderBlockBrandPivot/HeaderBlockBrandPivot.stories.tsx
@@ -2,13 +2,21 @@ import styled from '@emotion/styled'
 import { colorsV3 } from '@hedviginsurance/brand'
 import { boolean, select, withKnobs } from '@storybook/addon-knobs'
 import React from 'react'
+import StoryRouter from 'storybook-react-router'
 import { globalStoryMock, minimalColorMap } from 'utils/storybook'
 import { Header } from '.'
+import { Hero } from '../HeroImageBlockBrandPivot/HeroImageBlockBrandPivot'
 
 export default {
   title: 'Blocks/HeaderBlock',
   component: Header,
-  decorators: [withKnobs],
+  decorators: [withKnobs, StoryRouter()],
+  parameters: {
+    backgrounds: [
+      { name: 'gray900', value: colorsV3.gray900, default: true },
+      { name: 'gray100', value: colorsV3.gray100 },
+    ],
+  },
 }
 
 const headerBaseProps = {
@@ -42,12 +50,33 @@ export const Default = () => (
   </div>
 )
 
-Default.story = {
-  parameters: {
-    backgrounds: [
-      { name: 'gray500', value: colorsV3.gray500 },
-      { name: 'gray900', value: colorsV3.gray900, default: true },
-      { name: 'white', value: colorsV3.white },
-    ],
-  },
-}
+export const WithHero = () => (
+  <div>
+    <Header
+      {...headerBaseProps}
+      story={globalStoryMock}
+      is_transparent={boolean('Is Transparent', true)}
+      inverse_colors={boolean('Inverse Colors (transparent header only)', true)}
+      cta_color={
+        minimalColorMap[
+          select('CTA color', Object.keys(minimalColorMap), 'standard-inverse')
+        ]
+      }
+      cta_style={select(
+        'CTA style',
+        ['outlined', 'filled', 'plain'],
+        'outlined',
+      )}
+    />
+    <Hero
+      _uid="1234"
+      component="hero"
+      headline="Hjälp så som du aldrig kunnat föreställa dig den"
+      headline_font_size="md"
+      image="https://source.unsplash.com/user/heytowner/?orientation=landscape"
+      image_mobile=""
+      story={globalStoryMock}
+    />
+    <ScrollContainer />
+  </div>
+)

--- a/src/blocks/HeaderBlockBrandPivot/HeaderTop.tsx
+++ b/src/blocks/HeaderBlockBrandPivot/HeaderTop.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled'
 import { colorsV3 } from '@hedviginsurance/brand'
 import { MOBILE_BP_UP, SITE_MAX_WIDTH } from 'components/blockHelpers'
 import { ContextContainer } from 'components/containers/ContextContainer'
+import { Chevron } from 'components/icons/Chevron'
 import { Cross } from 'components/icons/Cross'
 import { Norway } from 'components/icons/flags/Norway'
 import { Sweden } from 'components/icons/flags/Sweden'
@@ -69,18 +70,17 @@ const MarketPickerToggle = styled.button`
     outline: 0;
   }
 
-  &:after {
-    display: inline-block;
-    content: '';
-    margin-top: 1px;
-    margin-left: 0.5rem;
-    border-width: 6px 6px 0 6px;
-    border-color: currentColor transparent transparent transparent;
-    border-style: solid;
+  svg:first-of-type {
+    margin-right: 0.375rem;
   }
 
-  svg {
-    margin-right: 0.5rem;
+  svg:last-of-type {
+    margin-left: 0.375rem;
+    font-size: 0.75rem;
+  }
+
+  span {
+    line-height: 1;
   }
 `
 
@@ -211,6 +211,7 @@ export const HeaderTop: React.FC<HeaderTopProps> = ({
               <MarketPickerToggle onClick={toggleHandler}>
                 <Globe size="1.5rem" />
                 <span>{getMarketLocale(context.lang)}</span>
+                <Chevron />
               </MarketPickerToggle>
               <MarketPickerWrapper isOpen={openMarketPicker} inverse={inverse}>
                 <MarketList>

--- a/src/blocks/HeaderBlockBrandPivot/MenuItem.tsx
+++ b/src/blocks/HeaderBlockBrandPivot/MenuItem.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled'
 import { colorsV3, fonts } from '@hedviginsurance/brand'
+import { Chevron } from 'components/icons/Chevron'
 import { Container } from 'constate'
 import React from 'react'
 import AnimateHeight from 'react-animate-height'
@@ -13,6 +14,7 @@ const MenuListItem = styled('li')({
   padding: 0,
 
   [TABLET_BP_UP]: {
+    display: 'flex',
     paddingLeft: '1.5rem',
     paddingRight: '1.5rem',
   },
@@ -55,13 +57,9 @@ const MenuLink = styled('a')({
 
   [TABLET_BP_DOWN]: {
     display: 'inline-block',
-    padding: `1.25rem 1rem 1.25rem 2rem`,
+    padding: `0.625rem 0.5rem 0.625rem 1.5rem`,
     fontFamily: fonts.FAVORIT,
     fontSize: '2.5rem',
-
-    '&:first-of-type': {
-      paddingTop: 0,
-    },
   },
 })
 const MenuFakeLink = styled(MenuLink)({ cursor: 'default' }).withComponent(
@@ -79,25 +77,28 @@ const DropdownMenuLink = styled(MenuLink)({
 })
 
 const Toggler = styled('button')<{ isOpen: boolean }>(({ isOpen }) => ({
+  position: 'relative',
+  top: -2,
   appearance: 'none',
   background: 0,
   border: 0,
+  padding: '1rem 0.5rem',
+  fontSize: '1rem',
   color: 'inherit',
 
-  '&:before': {
-    position: 'relative',
-    display: 'inline-block',
-    content: '" "',
-    width: 0,
-    height: 0,
-    top: -1.5,
-    borderWidth: '6px 5px 0 5px',
-    borderColor: 'currentColor transparent transparent transparent',
-    borderStyle: 'solid',
-    [TABLET_BP_DOWN]: {
-      top: -8,
-      transform: isOpen ? 'rotate(180deg)' : 'rotate(0deg)',
-      transition: 'transform 250ms',
+  svg: {
+    fontSize: '1.125rem',
+    transform: isOpen ? 'rotate(180deg)' : 'rotate(0deg)',
+    transition: 'transform 250ms',
+  },
+
+  [TABLET_BP_UP]: {
+    top: 1,
+    paddingTop: 0,
+    paddingBottom: 0,
+    svg: {
+      fontSize: '0.75rem',
+      transform: 'none',
     },
   },
 }))
@@ -186,10 +187,9 @@ export const MenuItem: React.FunctionComponent<{ menuItem: MenuItemType }> = ({
         )}
 
         {menuItem.menu_items && menuItem.menu_items.length > 0 && (
-          <Toggler
-            onClick={isOpen ? closeWithoutDelay : open}
-            isOpen={isOpen}
-          />
+          <Toggler onClick={isOpen ? closeWithoutDelay : open} isOpen={isOpen}>
+            <Chevron />
+          </Toggler>
         )}
 
         {menuItem.menu_items && menuItem.menu_items.length > 0 && (

--- a/src/blocks/HeaderBlockBrandPivot/MenuItem.tsx
+++ b/src/blocks/HeaderBlockBrandPivot/MenuItem.tsx
@@ -5,12 +5,17 @@ import React from 'react'
 import AnimateHeight from 'react-animate-height'
 import { MenuItem as MenuItemType } from '../../storyblok/StoryContainer'
 import { getStoryblokLinkUrl } from '../../utils/storyblok'
-import { TABLET_BP_DOWN } from './mobile'
+import { TABLET_BP_DOWN, TABLET_BP_UP } from './mobile'
 
 const MenuListItem = styled('li')({
   position: 'relative',
   margin: 0,
   padding: 0,
+
+  [TABLET_BP_UP]: {
+    paddingLeft: '1.5rem',
+    paddingRight: '1.5rem',
+  },
 })
 const DropdownMenuItemList = styled('ul')<{
   isClosing: boolean
@@ -19,31 +24,34 @@ const DropdownMenuItemList = styled('ul')<{
   display: isOpen ? 'flex' : 'none',
   flexDirection: 'column',
   position: 'absolute',
-  left: 0,
+  left: '50%',
   top: 'calc(100% + .75rem)',
   listStyle: 'none',
   margin: 0,
-  padding: '1.5rem 2rem .5rem 2rem',
+  padding: '1.5rem 0 .5rem',
   background: colorsV3.gray100,
   boxShadow: '0px 1px 2px rgba(0, 0, 0, 0.1), 0px 2px 5px rgba(0, 0, 0, 0.1);',
+  borderRadius: '0.5rem',
   opacity: isOpen && !isClosing ? 1 : 0,
   transition: 'opacity 150ms',
+  transform: 'translateX(-50%)',
   overflowY: 'hidden',
   color: colorsV3.gray900,
 
   [TABLET_BP_DOWN]: {
     position: 'static',
     boxShadow: 'none',
+    left: 0,
     padding: '.5rem 1rem',
     background: 'inherit',
     color: 'inherit',
     fontSize: '1.5rem',
+    transform: 'translateX(0)',
   },
 }))
 const MenuLink = styled('a')({
   color: 'inherit',
   textDecoration: 'none',
-  paddingLeft: '3rem',
 
   [TABLET_BP_DOWN]: {
     display: 'inline-block',
@@ -56,7 +64,7 @@ const MenuLink = styled('a')({
     },
   },
 })
-const MenuFakeLink = styled(MenuLink)({ cursor: 'normal' }).withComponent(
+const MenuFakeLink = styled(MenuLink)({ cursor: 'default' }).withComponent(
   'span',
 )
 const DropdownMenuLink = styled(MenuLink)({

--- a/src/blocks/HeaderBlockBrandPivot/index.tsx
+++ b/src/blocks/HeaderBlockBrandPivot/index.tsx
@@ -5,7 +5,7 @@ import { ContextContainer } from 'components/containers/ContextContainer'
 import { HedvigH } from 'components/icons/HedvigH'
 import React from 'react'
 import { AppLink } from '../../components/AppLink'
-import { ContentWrapper } from '../../components/blockHelpers'
+import { ContentWrapper, MOBILE_BP_DOWN } from '../../components/blockHelpers'
 import {
   ButtonLinkBrandPivot,
   ButtonStyleType,
@@ -73,6 +73,12 @@ const Filler = styled('div')({
   height: MOBILE_WRAPPER_HEIGHT,
   [TABLET_BP_UP]: {
     height: WRAPPER_HEIGHT,
+  },
+})
+
+const HeaderContentWrapper = styled(ContentWrapper)({
+  [MOBILE_BP_DOWN]: {
+    padding: '0 1.5rem',
   },
 })
 
@@ -271,7 +277,7 @@ export const Header: React.FC<{ story: GlobalStory } & HeaderBlockProps> = (
                 <HeaderBackgroundFiller
                   transparent={props.is_transparent && !isBelowThreshold}
                 />
-                <ContentWrapper brandPivot fullWidth>
+                <HeaderContentWrapper brandPivot fullWidth>
                   <InnerHeaderWrapper>
                     <LeftContainer>
                       <Burger
@@ -452,7 +458,7 @@ export const Header: React.FC<{ story: GlobalStory } & HeaderBlockProps> = (
                       </DesktopButtonWrapper>
                     </Menu>
                   </InnerHeaderWrapper>
-                </ContentWrapper>
+                </HeaderContentWrapper>
               </HeaderMain>
             </div>
           )}

--- a/src/blocks/HeroImageBlockBrandPivot/HeroImageBlockBrandPivot.stories.tsx
+++ b/src/blocks/HeroImageBlockBrandPivot/HeroImageBlockBrandPivot.stories.tsx
@@ -1,13 +1,14 @@
 import { boolean, select, withKnobs } from '@storybook/addon-knobs'
 import React from 'react'
-import { fontSizes, minimalColorMap } from 'utils/storybook'
+import StoryRouter from 'storybook-react-router'
+import { fontSizes, globalStoryMock, minimalColorMap } from 'utils/storybook'
 import { MarkdownHtmlComponent } from '../BaseBlockProps'
-import { HeroImageBlockBrandPivot } from './HeroImageBlockBrandPivot'
+import { Hero } from './HeroImageBlockBrandPivot'
 
 export default {
   title: 'Blocks/HeroBlock',
-  component: HeroImageBlockBrandPivot,
-  decorators: [withKnobs],
+  component: Hero,
+  decorators: [withKnobs, StoryRouter()],
 }
 
 const heroText: MarkdownHtmlComponent = {
@@ -26,12 +27,14 @@ const heroProps = {
   text: heroText,
   image: '',
   image_mobile: '',
+  story: globalStoryMock,
 }
 
-const image = 'https://cdn.hedvig.com/www/referrals/referrals-clean.png'
+const image =
+  'https://source.unsplash.com/user/heytowner/?orientation=landscape'
 
 export const Default = () => (
-  <HeroImageBlockBrandPivot
+  <Hero
     {...heroProps}
     headline_font_size={select('Font size', fontSizes, 'lg')}
     color={
@@ -49,10 +52,8 @@ export const Default = () => (
   />
 )
 export const WithImage = () => (
-  <HeroImageBlockBrandPivot
+  <Hero
     {...heroProps}
-    image={image}
-    image_mobile={image}
     headline_font_size={select('Font size', fontSizes, 'lg')}
     color={
       minimalColorMap[
@@ -64,6 +65,7 @@ export const WithImage = () => (
         select('Text color', Object.keys(minimalColorMap), 'standard-inverse')
       ]
     }
+    image={image}
     show_hedvig_wordmark={boolean('Show Hedvig wordmark', false)}
     use_display_font={boolean('Use display font', false)}
   />

--- a/src/blocks/HeroImageBlockBrandPivot/HeroImageBlockBrandPivot.tsx
+++ b/src/blocks/HeroImageBlockBrandPivot/HeroImageBlockBrandPivot.tsx
@@ -13,7 +13,7 @@ import { FontSizes, Heading } from 'components/Heading/Heading'
 import { HedvigH } from 'components/icons/HedvigH'
 import React from 'react'
 import { TextPosition } from 'src/utils/textPosition'
-import { GlobalStoryContainer } from 'storyblok/StoryContainer'
+import { GlobalStory, GlobalStoryContainer } from 'storyblok/StoryContainer'
 import { getStoryblokImage, getStoryblokLinkUrl, Image } from 'utils/storyblok'
 import {
   ContentWrapper,
@@ -131,7 +131,7 @@ export interface HeroImageBlockBrandPivotProps
   headline: string
   headline_font_size: FontSizes
   headline_font_size_mobile?: FontSizes
-  text: MarkdownHtmlComponent
+  text?: MarkdownHtmlComponent
   text_color?: MinimalColorComponent
   text_position?: TextPosition
   image: Image
@@ -145,7 +145,9 @@ export interface HeroImageBlockBrandPivotProps
   cta_mobile_style?: ButtonStyleType
 }
 
-export const HeroImageBlockBrandPivot: React.FC<HeroImageBlockBrandPivotProps> = ({
+export const Hero: React.FC<{
+  story: GlobalStory
+} & HeroImageBlockBrandPivotProps> = ({
   color,
   extra_styling,
   animate,
@@ -163,56 +165,63 @@ export const HeroImageBlockBrandPivot: React.FC<HeroImageBlockBrandPivotProps> =
   text_position = 'center',
   size,
   show_cta_mobile,
+  story,
   cta_mobile_color,
   cta_mobile_style,
 }) => {
   return (
-    <GlobalStoryContainer>
-      {({ globalStory }) => (
-        <WrapperWithExtraStyling
-          colorComponent={color}
-          extraStyling={extra_styling}
-          backgroundImage={getStoryblokImage(image)}
-          backgroundImageMobile={getStoryblokImage(image_mobile)}
-          size={size}
-          dynamicHeight={dynamic_height}
+    <WrapperWithExtraStyling
+      colorComponent={color}
+      extraStyling={extra_styling}
+      backgroundImage={getStoryblokImage(image)}
+      backgroundImageMobile={getStoryblokImage(image_mobile)}
+      size={size}
+      dynamicHeight={dynamic_height}
+    >
+      <ContentWrapper index={index} brandPivot>
+        <HeroHeadline
+          as="h1"
+          animate={animate}
+          size={headline_font_size}
+          mobileSize={headline_font_size_mobile}
+          textPosition={text_position}
+          useDisplayFont={use_display_font}
         >
-          <ContentWrapper index={index} brandPivot>
-            <HeroHeadline
-              as="h1"
-              animate={animate}
-              size={headline_font_size}
-              mobileSize={headline_font_size_mobile}
-              textPosition={text_position}
-              useDisplayFont={use_display_font}
+          {headline}
+          {show_hedvig_wordmark && (
+            <Wordmark>
+              <HedvigH />
+            </Wordmark>
+          )}
+        </HeroHeadline>
+        {text && (
+          <Text
+            dangerouslySetInnerHTML={{ __html: text?.html }}
+            animate={animate}
+            colorComponent={text_color}
+            textPosition={text_position}
+          />
+        )}
+        {show_cta_mobile && (
+          <ButtonWrapper>
+            <ButtonLinkBrandPivot
+              color={cta_mobile_color?.color}
+              styleType={cta_mobile_style}
+              href={getStoryblokLinkUrl(story.content.cta_link)}
             >
-              {headline}
-              {show_hedvig_wordmark && (
-                <Wordmark>
-                  <HedvigH />
-                </Wordmark>
-              )}
-            </HeroHeadline>
-            <Text
-              dangerouslySetInnerHTML={{ __html: text?.html }}
-              animate={animate}
-              colorComponent={text_color}
-              textPosition={text_position}
-            />
-            {show_cta_mobile && (
-              <ButtonWrapper>
-                <ButtonLinkBrandPivot
-                  color={cta_mobile_color?.color}
-                  styleType={cta_mobile_style}
-                  href={getStoryblokLinkUrl(globalStory.content.cta_link)}
-                >
-                  {globalStory.content.cta_label}
-                </ButtonLinkBrandPivot>
-              </ButtonWrapper>
-            )}
-          </ContentWrapper>
-        </WrapperWithExtraStyling>
-      )}
-    </GlobalStoryContainer>
+              {story.content.cta_label}
+            </ButtonLinkBrandPivot>
+          </ButtonWrapper>
+        )}
+      </ContentWrapper>
+    </WrapperWithExtraStyling>
   )
 }
+
+export const HeroImageBlockBrandPivot: React.FunctionComponent<HeroImageBlockBrandPivotProps> = (
+  heroBlockProps,
+) => (
+  <GlobalStoryContainer>
+    {({ globalStory }) => <Hero story={globalStory} {...heroBlockProps} />}
+  </GlobalStoryContainer>
+)

--- a/src/blocks/PerilsBlock/PerilsBlock.stories.tsx
+++ b/src/blocks/PerilsBlock/PerilsBlock.stories.tsx
@@ -1,12 +1,13 @@
 import { select, withKnobs } from '@storybook/addon-knobs'
 import React from 'react'
+import StoryRouter from 'storybook-react-router'
 import { minimalColorMap } from 'utils/storybook'
 import { ContractOption, PerilsBlock } from './PerilsBlock'
 
 export default {
   title: 'Blocks/PerilsBlock',
   component: PerilsBlock,
-  decorators: [withKnobs],
+  decorators: [withKnobs, StoryRouter()],
   parameters: {
     paddings: [
       { name: 'Medium', value: '16px', default: true },

--- a/src/components/GlobalStyles.tsx
+++ b/src/components/GlobalStyles.tsx
@@ -85,3 +85,9 @@ export const globalStyles = css`
     font-size: inherit;
   }
 `
+export const globalStylesStorybook = css`
+  ${globalStyles}
+  body {
+    background-color: transparent;
+  }
+`

--- a/src/utils/storybook.ts
+++ b/src/utils/storybook.ts
@@ -44,19 +44,51 @@ export const link: LinkComponent = {
 const headerMenuItems: MenuItem[] = [
   {
     _uid: '1',
-    label: 'Hemförsäkring',
+    label: 'Vår service',
     link,
     component: 'menu_item',
   },
   {
     _uid: '2',
-    label: 'Service',
+    label: 'Vårt skydd',
     link,
     component: 'menu_item',
   },
   {
     _uid: '3',
-    label: 'Om oss',
+    label: 'Hemförsäkring',
+    link,
+    component: 'menu_item',
+    menu_items: [
+      {
+        _uid: '11',
+        label: 'Hyresrätt & Andrahand',
+        link,
+        component: 'menu_item',
+      },
+      {
+        _uid: '12',
+        label: 'Bostadsrätt',
+        link,
+        component: 'menu_item',
+      },
+      {
+        _uid: '13',
+        label: 'Student',
+        link,
+        component: 'menu_item',
+      },
+      {
+        _uid: '14',
+        label: 'Villa',
+        link,
+        component: 'menu_item',
+      },
+    ],
+  },
+  {
+    _uid: '4',
+    label: 'Om Hedvig',
     link,
     component: 'menu_item',
   },


### PR DESCRIPTION
In this PR:
- A bunch of adjustments for header 
- Fix broken stories and storybook setup  

Before:
<img width="1567" alt="Screenshot 2020-05-06 at 15 28 09" src="https://user-images.githubusercontent.com/6661511/81182587-456bde00-8fae-11ea-9693-092033670b38.png">

Now:
<img width="1567" alt="Screenshot 2020-05-06 at 15 29 31" src="https://user-images.githubusercontent.com/6661511/81182672-68968d80-8fae-11ea-98ac-2fba0fb828af.png">

