### PR TITLE
Fix/accordion block brand pivot

### DIFF
--- a/src/blocks/AccordionBlock/AccordionBlock.stories.tsx
+++ b/src/blocks/AccordionBlock/AccordionBlock.stories.tsx
@@ -1,14 +1,11 @@
 import { select, withKnobs } from '@storybook/addon-knobs'
 import React from 'react'
 import { minimalColorMap } from 'utils/storybook'
-import {
-  AccordionBlockBrandPivot,
-  AccordionBlockProps,
-} from './AccordionBlockBandPivot'
+import { AccordionBlock, AccordionBlockProps } from './AccordionBlock'
 
 export default {
-  title: 'Blocks/AccotdionBlock',
-  component: AccordionBlockBrandPivot,
+  title: 'Blocks/AccordionBlock',
+  component: AccordionBlock,
   decorators: [withKnobs],
 }
 
@@ -90,7 +87,7 @@ const accordionProps: AccordionBlockProps = {
   ],
 }
 export const Default = () => (
-  <AccordionBlockBrandPivot
+  <AccordionBlock
     color={
       minimalColorMap[select('color', Object.keys(minimalColorMap), 'standard')]
     }

--- a/src/blocks/AccordionBlock/AccordionBlock.tsx
+++ b/src/blocks/AccordionBlock/AccordionBlock.tsx
@@ -100,8 +100,12 @@ const AccordionContent = styled('div')({
   overflowY: 'hidden',
 
   [TABLET_BP_UP]: {
-    padding: '3rem',
+    padding: '3rem 3rem 1.5rem 3rem',
     '& p': {
+      marginTop: 0,
+      marginBottom: '1rem',
+    },
+    '& p:last-child': {
       margin: 0,
     },
   },

--- a/src/blocks/AccordionBlock/AccordionBlock.tsx
+++ b/src/blocks/AccordionBlock/AccordionBlock.tsx
@@ -165,7 +165,7 @@ export interface AccordionBlockProps extends BrandPivotBaseBlockProps {
   accordions: ReadonlyArray<AccordionProps>
 }
 
-export const AccordionBlockBrandPivot: React.FunctionComponent<AccordionBlockProps> = ({
+export const AccordionBlock: React.FunctionComponent<AccordionBlockProps> = ({
   accordions,
   color,
   extra_styling,

--- a/src/blocks/AccordionBlock/AccordionBlock.tsx
+++ b/src/blocks/AccordionBlock/AccordionBlock.tsx
@@ -100,8 +100,10 @@ const AccordionContent = styled('div')({
   overflowY: 'hidden',
 
   [TABLET_BP_UP]: {
-    paddingTop: '2rem',
-    paddingBottom: '2rem',
+    padding: '3rem',
+    '& p': {
+      margin: 0,
+    },
   },
 })
 

--- a/src/blocks/AccordionBlock/AccordionBlock.tsx
+++ b/src/blocks/AccordionBlock/AccordionBlock.tsx
@@ -113,8 +113,6 @@ const ExpanderWrapper = styled('div')({
   flexShrink: 0,
   width: '1.625rem',
   height: '1.625rem',
-  border: '1px solid currentColor',
-  borderRadius: '0.25rem',
 
   [TABLET_BP_UP]: {
     width: '3rem',

--- a/src/blocks/index.tsx
+++ b/src/blocks/index.tsx
@@ -4,7 +4,7 @@ import { HeroImageBlockBrandPivot } from 'blocks/HeroImageBlockBrandPivot/HeroIm
 import { ImageTextBlockBrandPivot } from 'blocks/ImageTextBlockBrandPivot'
 import { YoutubeVideoBlock } from 'blocks/YoutubeVideoBlock/YoutubeVideoBlock'
 import React from 'react'
-import { AccordionBlockBrandPivot } from './AccordionBlockBandPivot/AccordionBlockBandPivot'
+import { AccordionBlock } from './AccordionBlock/AccordionBlock'
 import { AppButtonsBlock } from './AppButtonsBlock'
 import { BackgroundVideoBlock } from './BackgroundVideoBlock'
 import { BannerBlock } from './BannerBlock/BannerBlock'
@@ -25,8 +25,8 @@ import { TitleParagraphBlockBrandPivot } from './TitleParagraphBlockBrandPivot/T
 const blockComponents = {
   app_buttons_block: AppButtonsBlock,
   header_block_brand_pivot: HeaderBlockBrandPivot,
-  accordion_block: AccordionBlockBrandPivot,
-  accordion_block_brand_pivot: AccordionBlockBrandPivot,
+  accordion_block: AccordionBlock,
+  accordion_block_brand_pivot: AccordionBlock,
   banner_block: BannerBlock,
   bullet_point_block_brand_pivot: BulletPointBlockBrandPivot,
   column_text_block: ColumnTextBlock,


### PR DESCRIPTION
### This PR entails the following:
1) Replacing the name `AccordionBlockBandPivot` (yes the "r" was left out, it's not a typo) with `AccordionBlock` since the pivoting is done I guess?
2) Changing design of the `AccordionBlock` component slightly - remove border from `ExpanderWrapper` and add more padding to `AccordionContent` `div`. This was requested (from Ermir I think?) in the "FAQ" ticket in the project board for "Web iterations".

### Screenshots
**New design:**
![image](https://user-images.githubusercontent.com/42962286/91421998-e54bc100-e856-11ea-8bb8-3e0e69184d01.png)

**Old design:**
![image](https://user-images.githubusercontent.com/42962286/91422035-f0065600-e856-11ea-8891-dccce3653060.png)
