### PR TITLE
Add query string to favicons to forces clients to fetch the newest one

### DIFF
--- a/src/server/utils/favicons.ts
+++ b/src/server/utils/favicons.ts
@@ -1,19 +1,19 @@
 export const favicons = `
-<link rel="apple-touch-icon" sizes="57x57" href="/assets-next/favicons/apple-icon-57x57.png">
-<link rel="apple-touch-icon" sizes="60x60" href="/assets-next/favicons/apple-icon-60x60.png">
-<link rel="apple-touch-icon" sizes="72x72" href="/assets-next/favicons/apple-icon-72x72.png">
-<link rel="apple-touch-icon" sizes="76x76" href="/assets-next/favicons/apple-icon-76x76.png">
-<link rel="apple-touch-icon" sizes="114x114" href="/assets-next/favicons/apple-icon-114x114.png">
-<link rel="apple-touch-icon" sizes="120x120" href="/assets-next/favicons/apple-icon-120x120.png">
-<link rel="apple-touch-icon" sizes="144x144" href="/assets-next/favicons/apple-icon-144x144.png">
-<link rel="apple-touch-icon" sizes="152x152" href="/assets-next/favicons/apple-icon-152x152.png">
-<link rel="apple-touch-icon" sizes="180x180" href="/assets-next/favicons/apple-icon-180x180.png">
-<link rel="icon" type="image/png" sizes="192x192"  href="/assets-next/favicons/android-icon-192x192.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/assets-next/favicons/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="96x96" href="/assets-next/favicons/favicon-96x96.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/assets-next/favicons/favicon-16x16.png">
+<link rel="apple-touch-icon" sizes="57x57" href="/assets-next/favicons/apple-icon-57x57.png?v=2">
+<link rel="apple-touch-icon" sizes="60x60" href="/assets-next/favicons/apple-icon-60x60.png?v=2">
+<link rel="apple-touch-icon" sizes="72x72" href="/assets-next/favicons/apple-icon-72x72.png?v=2">
+<link rel="apple-touch-icon" sizes="76x76" href="/assets-next/favicons/apple-icon-76x76.png?v=2">
+<link rel="apple-touch-icon" sizes="114x114" href="/assets-next/favicons/apple-icon-114x114.png?v=2">
+<link rel="apple-touch-icon" sizes="120x120" href="/assets-next/favicons/apple-icon-120x120.png?v=2">
+<link rel="apple-touch-icon" sizes="144x144" href="/assets-next/favicons/apple-icon-144x144.png?v=2">
+<link rel="apple-touch-icon" sizes="152x152" href="/assets-next/favicons/apple-icon-152x152.png?v=2">
+<link rel="apple-touch-icon" sizes="180x180" href="/assets-next/favicons/apple-icon-180x180.png?v=2">
+<link rel="icon" type="image/png" sizes="192x192"  href="/assets-next/favicons/android-icon-192x192.png?v=2">
+<link rel="icon" type="image/png" sizes="32x32" href="/assets-next/favicons/favicon-32x32.png?v=2">
+<link rel="icon" type="image/png" sizes="96x96" href="/assets-next/favicons/favicon-96x96.png?v=2">
+<link rel="icon" type="image/png" sizes="16x16" href="/assets-next/favicons/favicon-16x16.png?v=2">
 <link rel="manifest" href="/assets-next/favicons/manifest.json">
 <meta name="msapplication-TileColor" content="#121212">
-<meta name="msapplication-TileImage" content="/assets-next/favicons/ms-icon-144x144.png">
+<meta name="msapplication-TileImage" content="/assets-next/favicons/ms-icon-144x144.png?v=2">
 <meta name="theme-color" content="#121212">
 `


### PR DESCRIPTION
## Why
The old logo was shown as favicon. When removing the old favioncs we reverted back to old path. However, clients heavily cache favicons so the only way to force an update is to change the path. And adding a query string feels like the least cumbersome. 

![IMG_3063](https://user-images.githubusercontent.com/6661511/93870661-d6c5bd80-fccd-11ea-8c6c-656f91eee574.jpg)
