### PR TITLE
[HVG-144] Fix / cookie consent component

### DIFF
--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -2,10 +2,7 @@ import styled from '@emotion/styled'
 import { colorsV2 } from '@hedviginsurance/brand'
 import Cookies from 'js-cookie'
 import React, { useState, useEffect } from 'react'
-import {
-  CONTENT_GUTTER,
-  CONTENT_MAX_WIDTH_DEPRECATED,
-} from 'components/blockHelpers'
+import { CONTENT_GUTTER, CONTENT_MAX_WIDTH } from 'components/blockHelpers'
 import { GlobalStoryContainer } from 'storyblok/StoryContainer'
 
 const OuterWrapper = styled('div')<{ visible: boolean; closing: boolean }>(
@@ -33,12 +30,15 @@ const InnerWrapper = styled('div')({
   width: '100%',
   padding: CONTENT_GUTTER,
 
-  ...CONTENT_MAX_WIDTH_DEPRECATED,
+  ...CONTENT_MAX_WIDTH,
 })
+
 const ContentWrapper = styled('div')({
   fontSize: '0.8rem',
-  paddingRight: '1rem',
-  maxWidth: 1000,
+  paddingRight: '2rem',
+  '> p': {
+    margin: 0,
+  },
 })
 const CloseButton = styled('button')({
   display: 'flex',
@@ -47,7 +47,6 @@ const CloseButton = styled('button')({
   width: '3rem',
   height: '3rem',
   padding: 0,
-  paddingBottom: '0.4rem',
   fontSize: '2rem',
   background: 'transparent',
   color: colorsV2.darkgray,
@@ -94,7 +93,7 @@ export const CookieConsent: React.FC = () => {
             Cookies.set('_hvcookie', 'yes', { path: '/' })
           }}
         >
-          &times;
+          &#x2715;
         </CloseButton>
       </InnerWrapper>
     </OuterWrapper>

--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -2,11 +2,11 @@ import styled from '@emotion/styled'
 import { colorsV2 } from '@hedviginsurance/brand'
 import Cookies from 'js-cookie'
 import React, { useState, useEffect } from 'react'
-import { useLocation } from 'react-router'
 import {
   CONTENT_GUTTER,
   CONTENT_MAX_WIDTH_DEPRECATED,
 } from 'components/blockHelpers'
+import { GlobalStoryContainer } from 'storyblok/StoryContainer'
 
 const OuterWrapper = styled('div')<{ visible: boolean; closing: boolean }>(
   ({ visible, closing }) => ({
@@ -63,7 +63,6 @@ const CloseButton = styled('button')({
 })
 
 export const CookieConsent: React.FC = () => {
-  const location = useLocation()
   const [isVisible, setVisible] = useState(false)
   const [isClosing, setIsClosing] = useState(false)
   useEffect(() => {
@@ -79,31 +78,15 @@ export const CookieConsent: React.FC = () => {
   return (
     <OuterWrapper visible={isVisible} closing={isClosing}>
       <InnerWrapper>
-        <ContentWrapper>
-          {/^\/en(\/|$)/.test(location.pathname) ? (
-            <>
-              We use <a href="/en/legal">cookies</a> to manage logins, to
-              strengthen security and to improve the overall service for our
-              members. If you don’t want us to use cookies, you can easily turn
-              it off through your browser. <a href="/en/legal">Read more</a>
-            </>
-          ) : /^\/no(\/|$)/.test(location.pathname) ? (
-            <>
-              We use <a href="/en/legal">cookies</a> to manage logins, to
-              strengthen security and to improve the overall service for our
-              members. If you don’t want us to use cookies, you can easily turn
-              it off through your browser. <a href="/en/legal">Read more</a>
-            </>
-          ) : (
-            <>
-              Vi använder <a href="/legal">cookies</a>, en liten datafil som
-              lagras i din dator, för att hantera inloggningar, öka säkerheten
-              för våra användare och förbättra de tjänster vi erbjuder. Om du
-              inte vill att vi använder cookies kan du enkelt stänga av det i
-              din browser. <a href="/legal">Läs mer</a>
-            </>
+        <GlobalStoryContainer>
+          {({ globalStory }) => (
+            <ContentWrapper
+              dangerouslySetInnerHTML={{
+                __html: globalStory.content.cookie_consent_message?.html,
+              }}
+            />
           )}
-        </ContentWrapper>
+        </GlobalStoryContainer>
         <CloseButton
           onClick={() => {
             setIsClosing(true)

--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -47,7 +47,7 @@ const CloseButton = styled('button')({
   width: '3rem',
   height: '3rem',
   padding: 0,
-  fontSize: '2rem',
+  fontSize: '1.25rem',
   background: 'transparent',
   color: colorsV2.darkgray,
   border: '1px solid ' + colorsV2.darkgray,

--- a/src/storyblok/StoryContainer.tsx
+++ b/src/storyblok/StoryContainer.tsx
@@ -108,7 +108,7 @@ export interface GlobalStory extends Story {
     peril_modal_coverage_title?: string
     peril_modal_exceptions_title?: string
     four_oh_four_title?: string
-    html_lang?: string
+    cookie_consent_message: MarkdownHtmlComponent
   }
 }
 

--- a/src/utils/storybook.ts
+++ b/src/utils/storybook.ts
@@ -262,6 +262,15 @@ const safetyText: MarkdownHtmlComponent = {
   plugin: 'markdown-html',
 }
 
+const cookie_consent_message: MarkdownHtmlComponent = {
+  _uid: '5',
+  html:
+    'Vi använder cookies, en liten datafil som lagras i din dator, för att hantera inloggningar, öka säkerheten för våra användare och förbättra de tjänster vi erbjuder. Om du inte vill att vi använder cookies kan du enkelt stänga av det i din browser. <a href="/legal">Läs mer</a>',
+  original:
+    'Vi använder cookies, en liten datafil som lagras i din dator, för att hantera inloggningar, öka säkerheten för våra användare och förbättra de tjänster vi erbjuder. Om du inte vill att vi använder cookies kan du enkelt stänga av det i din browser. <a href="/legal">Läs mer</a>',
+  plugin: 'markdown-html',
+}
+
 export const globalStoryMock: GlobalStory = {
   name: 'storybook mock',
   created_at: '',
@@ -290,5 +299,6 @@ export const globalStoryMock: GlobalStory = {
     peril_modal_info_title: 'Att tänka på',
     peril_modal_coverage_title: 'Det här täcks',
     peril_modal_exceptions_title: 'Undantag',
+    cookie_consent_message: cookie_consent_message,
   },
 }

--- a/storyblok/components.json
+++ b/storyblok/components.json
@@ -670,10 +670,17 @@
         },
         "locale": {
           "type": "section",
-          "keys": ["four_oh_four_title"]
+          "keys": ["four_oh_four_title", "cookie_consent_message"]
         },
         "four_oh_four_title": {
           "type": "text"
+        },
+        "cookie_consent_message": {
+          "type": "custom",
+          "required": true,
+          "translatable": true,
+          "field_type": "markdown-html",
+          "options": []
         }
       },
       "image": null,


### PR DESCRIPTION
### What?
Get text content for `CookieConsent.tsx` from Storyblok global story instead of having it hard coded in the component:
1) Add a `cookie_consent_message` to Storyblok `components.json` file and add a `cookie_consent_message` property of type `MarkdownHtmlComponent` to the `GlobalStory` interface in `StoryContainer.tsx`.
2) Replace hard coded text and conditional render from `CookieConsent` component and replace it with a `<GlobalStoryContainer>` in order to render the `cookie_consent_message` html as `dangerouslySetInnerHTML`.
3) Add a `cookie_consent_message` object to `globalStoryMock` in `storybook.ts` since TypeScript was screaming about it.

Finally make some minor styling fixes and change the x symbol in `CloseButton` in `CookieConsent` to one that isn't positioned weirdly in the button. It's also bigger and I hope that's fine :)

### Why?
The cookie consent/information element did not display copy in the right language, since the hard coded locale strings that was checked to conditionally render the right text (the text was also hard coded and it really shouldn't be) wasn't right.

_Referenced ticket [here](https://hedvig.atlassian.net/browse/HVG-144)_


### Screenshots
_/se:_
<img width="1574" alt="2020-10-12-cookie-consent-smaller-x-se" src="https://user-images.githubusercontent.com/42962286/95755021-26cbea80-0ca4-11eb-9c62-6d69554fed47.png">

_/no-en:_
<img width="1574" alt="2020-10-12-cookie-consent-smaller-x-no-en" src="https://user-images.githubusercontent.com/42962286/95755036-2fbcbc00-0ca4-11eb-9c5b-084cd2ee4d5d.png">



