### PR TITLE
Recognise locale correctly for hreflang

### DIFF
--- a/src/utils/meta.tsx
+++ b/src/utils/meta.tsx
@@ -24,7 +24,7 @@ const getPageTitleFromStory = (story?: Story) => {
 }
 
 const getAlternateLang = (fullSlug: string) => {
-  const localeSlug: LocaleData['label'] = fullSlug.replace('/', '')
+  const localeSlug: LocaleData['label'] = fullSlug.split('/')[0]
   const marketLocale = getLocaleData(localeSlug)
   return marketLocale.hrefLang
 }


### PR DESCRIPTION
Previously we accidentally didn't pass the correct locale to get the function that gets hreflang for a page alternative, meaning we fell back to `se` for every language.