### PR TITLE
Fix potential SEO bug

### DIFF
--- a/src/blocks/HeroBlock/HeroBlock.stories.tsx
+++ b/src/blocks/HeroBlock/HeroBlock.stories.tsx
@@ -88,7 +88,7 @@ export const WithCTA = () => (
 export const WithoutImage = () => (
   <HeroBlock
     {...heroProps}
-    headline="Hjälp så som du aldrig kunnat föreställa dig den"
+    headline="Bostadsrätt"
     headline_font_size_mobile={select('Font size mobile', fontSizes, 'lg')}
     headline_font_size={select('Font size', fontSizes, 'lg')}
     color={

--- a/src/blocks/HeroBlock/HeroBlock.tsx
+++ b/src/blocks/HeroBlock/HeroBlock.tsx
@@ -69,7 +69,7 @@ const HeroContent = styled(ContentWrapper)`
   z-index: 2;
 `
 
-const HeroHeadline = styled(Heading)<Animatable>`
+const HeadlineWrapper = styled.div<Animatable>`
   position: relative;
   animation: ${(props) =>
     props.animate
@@ -91,6 +91,10 @@ const HeroHeadline = styled(Heading)<Animatable>`
       display: block;
     }
   }
+`
+
+const HeroHeadline = styled(Heading)`
+  display: inline;
 `
 
 const Text = styled.div<TextProps>`
@@ -209,20 +213,20 @@ export const HeroBlock: React.FC<HeroBlockProps> = ({
       height={height}
     >
       <HeroContent index={index} brandPivot fullWidth>
-        <HeroHeadline
-          as="h1"
-          animate={animate}
-          size={headline_font_size}
-          mobileSize={headline_font_size_mobile}
-          textPosition={text_position}
-        >
-          <span dangerouslySetInnerHTML={{ __html: headline }} />
+        <HeadlineWrapper animate={animate}>
+          <HeroHeadline
+            as="h1"
+            size={headline_font_size}
+            mobileSize={headline_font_size_mobile}
+            textPosition={text_position}
+            dangerouslySetInnerHTML={{ __html: headline }}
+          />
           {show_hedvig_wordmark && (
             <Wordmark>
               <HedvigH />
             </Wordmark>
           )}
-        </HeroHeadline>
+        </HeadlineWrapper>
         {text && (
           <Text
             dangerouslySetInnerHTML={{ __html: text?.html }}


### PR DESCRIPTION
Don't nest children inside H1. According to this report SEO is punished since server side rendering puts a style tag right before an element (crowding the H1). I'm not sure that's how google interprets it but better safe than sorry ey :D 

<img width="848" alt="Screen Shot 2020-11-11 at 12 57 33" src="https://user-images.githubusercontent.com/6661511/98977185-9f7acc80-2518-11eb-8fb1-1058502bc799.png">

[HVG-236]


[HVG-236]: https://hedvig.atlassian.net/browse/HVG-236