### PR TITLE
Remove the background animation on all blocks

### DIFF
--- a/src/blocks/HeaderBlockBrandPivot/index.tsx
+++ b/src/blocks/HeaderBlockBrandPivot/index.tsx
@@ -234,7 +234,11 @@ export const Header: React.FC<{ story: GlobalStory } & HeaderBlockProps> = (
   const [isBelowThreshold, setIsBelowThreshold] = useState<boolean>(false)
   const [buttonColor, setButtonColor] = useState<
     minimalColorComponentColors | undefined
-  >(props.cta_color?.color)
+  >(
+    props.inverse_colors && props.is_transparent
+      ? InverseColors.DEFAULT
+      : props.cta_color?.color,
+  )
 
   const updateHeader = useCallback(() => {
     if (isBelowScrollThreshold()) {

--- a/src/components/blockHelpers.tsx
+++ b/src/components/blockHelpers.tsx
@@ -1,4 +1,3 @@
-import { keyframes } from '@emotion/core'
 import styled from '@emotion/styled'
 import { colors, colorsV3, fonts } from '@hedviginsurance/brand'
 import { match } from 'matchly'
@@ -333,10 +332,6 @@ export const SectionWrapperComponent = styled(SectionWrapperComponentUnstyled)<
 >`
   ${({ extraStyling = '' }) => String(extraStyling)}
 `
-const fadeIn = keyframes({
-  from: { opacity: 0 },
-  to: { opacity: 1 },
-})
 const SectionBackground = styled('div')<{
   backgroundImage?: string
   backgroundImageMobile?: string
@@ -348,9 +343,6 @@ const SectionBackground = styled('div')<{
   bottom: 0,
   minHeight: '100%',
   minWidth: '100%',
-  opacity: 0,
-  animation: fadeIn + ' 500ms forwards',
-  animationDelay: '1000ms',
   backgroundColor:
     colorComponent?.plugin === 'hedvig_minimal_color_picker'
       ? getMinimalColorStyles(colorComponent.color ?? 'standard').background
@@ -449,7 +441,7 @@ export const ContentWrapper: React.FC<ContentWrapperProps> = ({
   >
     {({ isVisible }) => (
       <ContentWrapperStyled
-        visible={index <= 1 || isVisible}
+        visible={index <= 2 || isVisible}
         brandPivot={brandPivot}
         fullWidth={fullWidth}
         {...props}


### PR DESCRIPTION
To improve the first contentful paint speed and imo make loading nicer?
For me, running with and without animation locally, lighthouse performance is bumped from 57 to a good 66

So instead of this:

![ezgif com-video-to-gif(3)](https://user-images.githubusercontent.com/3954425/98983363-f5ec0900-2520-11eb-887f-9e302bef2c25.gif)


We do this:
![ezgif com-video-to-gif(4)](https://user-images.githubusercontent.com/3954425/98983381-fab0bd00-2520-11eb-8478-b0070c2a0cb6.gif)