### PR TITLE
[HVG-342] Codefresh

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,0 +1,4 @@
+FROM node:12.19.0
+
+RUN npm i -g --force yarn@1.22.10
+

--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.19.0
+FROM node:10.19.0
 
 RUN npm i -g --force yarn@1.22.10
 

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -1,0 +1,75 @@
+version: "1.0"
+stages:
+  - "clone"
+  - "install"
+  - "checks"
+
+steps:
+  clone:
+    title: "Cloning repository"
+    type: "git-clone"
+    repo: "HedvigInsurance/market-web"
+    revision: "${{CF_BRANCH}}"
+    git: "github"
+    stage: "clone"
+
+  build_dependency_container:
+    title: "Building Docker image"
+    type: "build"
+    image_name: "hedviginsurance/market-web"
+    disable_push: true
+    working_directory: "${{clone}}"
+    dockerfile: .ci/Dockerfile
+    stage: "install"
+
+  install_deps:
+    title: "Installing dependencies"
+    type: "freestyle"
+    image: "${{build_dependency_container}}"
+    working_directory: "${{clone}}"
+    commands:
+      - yarn
+    stage: "install"
+
+  checks:
+    title: "Running checks"
+    type: "parallel"
+    steps:
+      - title: "Linting"
+        type: "freestyle"
+        image: "${{build_dependency_container}}"
+        working_directory: "${{clone}}"
+        commands:
+          - yarn lint
+      - title: "Testing"
+        type: "freestyle"
+        image: "${{build_dependency_container}}"
+        working_directory: "${{clone}}"
+        commands:
+          - yarn test
+      - title: "Typecheck"
+        type: "freestyle"
+        image: "${{build_dependency_container}}"
+        working_directory: "${{clone}}"
+        commands:
+          - yarn typecheck
+    stage: "checks"
+
+  build_client:
+    title: "Building client"
+    type: "freestyle"
+    image: "${{build_dependency_container}}"
+    working_directory: "${{clone}}"
+    commands:
+      - yarn build-client
+    stage: "checks"
+
+  build_server:
+    title: "Building server"
+    type: "freestyle"
+    image: "${{build_dependency_container}}"
+    working_directory: "${{clone}}"
+    commands:
+      - yarn build-server
+    stage: "checks"
+

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@hedviginsurance/web-next",
+  "name": "@hedviginsurance/market-web",
   "version": "1.6.1",
   "description": "Template for the next web project",
   "main": "index.js",
-  "repository": "https://github.com/HedvigInsurance/web-next",
+  "repository": "https://github.com/HedvigInsurance/morket-web",
   "author": "Johan Palmfjord <johan.palmfjord@hedvig.com>",
   "types": "./types.d.ts",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.6.1",
   "description": "Template for the next web project",
   "main": "index.js",
-  "repository": "https://github.com/HedvigInsurance/morket-web",
+  "repository": "https://github.com/HedvigInsurance/market-web",
   "author": "Johan Palmfjord <johan.palmfjord@hedvig.com>",
   "types": "./types.d.ts",
   "engines": {


### PR DESCRIPTION
## What

Implement codefresh for CI checks instead of travis

## Why

Travis is slow and everything else is on Codefresh now

Ticket [here](https://hedvig.atlassian.net/browse/HVG-342)


Extra 🌮: Rename web-next to market-web in package.json