### PR TITLE
Replace https://www.hedvig.com with PUBLIC_HOST & fix frameguard (ie storyblok preview)

### DIFF
--- a/src/server/entry.tsx
+++ b/src/server/entry.tsx
@@ -64,6 +64,7 @@ if (process.env.USE_HELMET === 'true')
   app.use(
     koaHelmet({
       contentSecurityPolicy: false,
+      frameguard: false,
     }),
   )
 

--- a/src/utils/storyblok.ts
+++ b/src/utils/storyblok.ts
@@ -1,9 +1,16 @@
 import { LinkComponent } from '../storyblok/StoryContainer'
 
-export const getStoryblokLinkUrl = (link: LinkComponent) =>
-  link.linktype !== 'story' || /^\//.test(link.cached_url)
-    ? link.cached_url
-    : `/${link.cached_url}`
+export const getStoryblokLinkUrl = (link: LinkComponent) => {
+  const cachedLink =
+    link.linktype !== 'story' || /^\//.test(link.cached_url)
+      ? link.cached_url
+      : `/${link.cached_url}`
+  const publicHost = getPublicHost()
+  return publicHost
+    ? cachedLink.replace('https://www.hedvig.com', publicHost)
+    : cachedLink
+}
+
 export const getPublicHost = (): string | undefined => {
   if (
     typeof window === 'undefined' &&


### PR DESCRIPTION
This should only affect dev/staging environments, but basically ensures no (or at least fewer) links that are hard-coded to hedvig.com actually link to hedvig.com in the specific environment. If you're in the staging environment and press a cta you expect to reman in the staging environment right? This should ensure that behaviour to some extent, but can't handle if we link somewhere "directly" in copy, for example. But it's a first step at least 👍 

Extra 🌮 : Disable frameguard, since storyblok depends on iframes for its visual editor.