### PR TITLE
Fix / YoutubeVideoBlock infinite loop of rendering

### DIFF
--- a/src/blocks/YoutubeVideoBlock/YoutubeVideoBlock.tsx
+++ b/src/blocks/YoutubeVideoBlock/YoutubeVideoBlock.tsx
@@ -124,7 +124,7 @@ export const YoutubeVideoBlock: React.FunctionComponent<YoutubeVideoBlockProps> 
   index,
 }) => {
   const [isPlaying, setIsPlaying] = useState(false)
-  const [isPlayerLoaded, setPlayerLoaded] = useState(false)
+  const [isPlayerLoaded, setIsPlayerLoaded] = useState(false)
   const [isShowingOverlay, setIsShowingOverlay] = useState(true)
 
   useEffect(() => {
@@ -160,7 +160,7 @@ export const YoutubeVideoBlock: React.FunctionComponent<YoutubeVideoBlockProps> 
             frameBorder="0"
             onLoad={() => {
               if (isPlaying) {
-                setPlayerLoaded(true)
+                setIsPlayerLoaded(true)
               }
             }}
           />

--- a/src/blocks/YoutubeVideoBlock/YoutubeVideoBlock.tsx
+++ b/src/blocks/YoutubeVideoBlock/YoutubeVideoBlock.tsx
@@ -144,27 +144,24 @@ export const YoutubeVideoBlock: React.FunctionComponent<YoutubeVideoBlockProps> 
   const [isPlaying, setIsPlaying] = useState(false)
   const [isPlayerLoaded, setPlayerLoaded] = useState(false)
   const [isShowingOverlay, setIsShowingOverlay] = useState(true)
-  const [playerResizeInterval, setPlayerResizeInterval] = useState<
-    number | null
-  >(null)
   const [playerWidth, setPlayerWidth] = useState(0)
   const [playerHeight, setPlayerHeight] = useState(0)
   const imageRef = useRef<HTMLImageElement>(null)
 
   useEffect(() => {
-    setPlayerResizeInterval(
-      window.setInterval(() => {
-        setPlayerWidth(imageRef?.current?.width ?? 0)
-        setPlayerHeight(imageRef?.current?.height ?? 0)
-      }, 50),
-    )
+    const setPlayerSize = () => {
+      setPlayerWidth(imageRef?.current?.width ?? 0)
+      setPlayerHeight(imageRef?.current?.height ?? 0)
+    }
+
+    setPlayerSize()
+    window.addEventListener('resize', setPlayerSize)
 
     return () => {
-      if (playerResizeInterval) {
-        clearInterval(playerResizeInterval)
-      }
+      window.removeEventListener('resize', setPlayerSize)
     }
-  }, [playerResizeInterval])
+  }, [imageRef?.current?.width, imageRef?.current?.height])
+
   useEffect(() => {
     if (isPlaying && isPlayerLoaded) {
       setTimeout(() => {

--- a/src/blocks/YoutubeVideoBlock/YoutubeVideoBlock.tsx
+++ b/src/blocks/YoutubeVideoBlock/YoutubeVideoBlock.tsx
@@ -1,7 +1,7 @@
-import { css, keyframes } from '@emotion/core'
+import { keyframes } from '@emotion/core'
 import styled from '@emotion/styled'
 import { colorsV3 } from '@hedviginsurance/brand'
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import {
   BrandPivotBaseBlockProps,
   MarkdownHtmlComponent,
@@ -14,8 +14,12 @@ import {
 import { Caption } from 'components/Caption'
 import { Image } from 'utils/storyblok'
 
+const CONTENT_MAX_WIDTH = '828px'
+const PLAYER_WIDTH = '100%'
+const OVERLAY_FADE_TIME = 1500
+
 const StyledContentWrapper = styled(ContentWrapper)`
-  max-width: 828px;
+  max-width: ${CONTENT_MAX_WIDTH};
 `
 
 const InnerWrapper = styled.div`
@@ -24,37 +28,18 @@ const InnerWrapper = styled.div`
   justify-content: center;
 `
 
-const OVERLAY_FADE_TIME = 1500
 const Overlay = styled.div<{ isPlaying: boolean; isOnFront: boolean }>`
   position: relative;
   transition: opacity ${OVERLAY_FADE_TIME}ms;
   z-index: ${({ isOnFront }) => (isOnFront ? 2 : 0)};
+  opacity: ${({ isPlaying }) => (isPlaying ? 0 : 1)};
   color: ${colorsV3.gray100};
-
-  ${({ isPlaying }) =>
-    isPlaying
-      ? css`
-          opacity: 0;
-
-          button {
-            transform: scale(1.1);
-            transition: transform ${OVERLAY_FADE_TIME}ms;
-          }
-        `
-      : css`
-          opacity: 1;
-
-          button {
-            transform: scale(1);
-            transition: transform ${OVERLAY_FADE_TIME}ms;
-          }
-        `}
 `
 
 const OverlayImage = styled.img`
   display: block;
-  max-width: 828px;
-  width: 100%;
+  max-width: ${CONTENT_MAX_WIDTH};
+  width: ${PLAYER_WIDTH};
 `
 
 const OverlayText = styled.button`
@@ -103,7 +88,6 @@ const fade = keyframes`
 `
 const Spinner = styled.div`
   position: absolute;
-  text-align: center;
   top: 50%;
   left: 50%;
   width: 4rem;
@@ -115,15 +99,13 @@ const Spinner = styled.div`
 
   ${TABLET_BP_UP} {
     border-width: 3px;
-    width: 4rem;
-    height: 4rem;
   }
 `
 
-const VideoFrame = styled.iframe<{ width?: number; height?: number }>`
+const VideoFrame = styled.iframe`
   position: absolute;
-  width: ${({ width }) => width}px;
-  height: ${({ height }) => height}px;
+  width: ${PLAYER_WIDTH};
+  height: 100%;
   z-index: 1;
 `
 
@@ -144,23 +126,6 @@ export const YoutubeVideoBlock: React.FunctionComponent<YoutubeVideoBlockProps> 
   const [isPlaying, setIsPlaying] = useState(false)
   const [isPlayerLoaded, setPlayerLoaded] = useState(false)
   const [isShowingOverlay, setIsShowingOverlay] = useState(true)
-  const [playerWidth, setPlayerWidth] = useState(0)
-  const [playerHeight, setPlayerHeight] = useState(0)
-  const imageRef = useRef<HTMLImageElement>(null)
-
-  useEffect(() => {
-    const setPlayerSize = () => {
-      setPlayerWidth(imageRef?.current?.width ?? 0)
-      setPlayerHeight(imageRef?.current?.height ?? 0)
-    }
-
-    setPlayerSize()
-    window.addEventListener('resize', setPlayerSize)
-
-    return () => {
-      window.removeEventListener('resize', setPlayerSize)
-    }
-  }, [imageRef?.current?.width, imageRef?.current?.height])
 
   useEffect(() => {
     if (isPlaying && isPlayerLoaded) {
@@ -183,16 +148,12 @@ export const YoutubeVideoBlock: React.FunctionComponent<YoutubeVideoBlockProps> 
             isOnFront={isShowingOverlay}
           >
             {!isPlaying && (
-              <OverlayText onClick={() => setIsPlaying(!isPlaying)}>
-                Play
-              </OverlayText>
+              <OverlayText onClick={() => setIsPlaying(true)}>Play</OverlayText>
             )}
             {isPlaying && !isPlayerLoaded && <Spinner />}
-            <OverlayImage src={overlay_image} ref={imageRef} />
+            <OverlayImage src={overlay_image} />
           </Overlay>
           <VideoFrame
-            width={playerWidth}
-            height={playerHeight}
             src={`https://www.youtube.com/embed/${video_id}?autoplay=${
               isPlaying ? '1' : '0'
             }&controls=0&loop=1&playlist=${video_id}`}


### PR DESCRIPTION
## What?

<!-- What changes are made? If there are many significant changes, a list might be a good format. -->

1. Fix the infinite loop of re-rendering in `YoutubeVideoBlock.tsx`, caused by a dependency to a `useEffect`:
What we want is for the `VideoFrame` (a styled `iframe`) to have the same size as the `OverLayImage`. After solving the problem by replacing the `setInterval` function checking the size of the `OverLayImage` with a listener on the `'resize'` event in the order to change the 'playerWidth' and 'playerHeight' states, I realised that this issue could actually also be fixed by just setting the `VideoFrame` height to `100%` . 🙃

2. Some CSS refactoring, making some of the rules a little less complicated and extracting some values used in more than one place to variables. As far as I have been able to see none of this has changed any behaviour or styling of the rendered elements.

3. Change name of `setPlayerLoaded` to `setIsPlayerLoaded` (nothing else changed with this, just the name).

**Please note:** The autoplay doesn't always work, but that is the case without these changes as well. At some point that should probably be looked into but now is not the time in my opinion, since we have more important things to fix.

## Why?

<!-- Why are these changes made? -->
The entire page gets disabled (nothing happens when you click a link etc.) if this block is used the way it is constructed now, due to the infinite loop of re-rendering.

These changes will also make this component less complex.

<!-- If there is one, add the Jira issue ID in brackets below. This will create a link to that issue. -->
_Referenced ticket: [HVG-627]_


<!-- And, if that makes sense, add screenshots and/or GIF's below -->

## GIF
**The Youtube Video Block used at /se/about-us - The same look and behaviour as before, minus the infinite loop:**

![2020-12-07-youtube-video-block](https://user-images.githubusercontent.com/42962286/101346937-9bc53600-3889-11eb-93d4-df3820afc352.gif)




[HVG-627]: https://hedvig.atlassian.net/browse/HVG-627