### PR TITLE
Add Trustpilot reviews slider

### DIFF
--- a/src/blocks/TrustpilotBlock/TrustpilotBlock.tsx
+++ b/src/blocks/TrustpilotBlock/TrustpilotBlock.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useRef } from 'react'
+import styled from '@emotion/styled'
+import { colorsV3 } from '@hedviginsurance/brand'
+import { ContentWrapper } from 'components/blockHelpers'
+import { ContextContainer } from 'components/containers/ContextContainer'
+
+const TrustpilotWrapper = styled(ContentWrapper)`
+  && {
+    max-width: 1200px;
+  }
+`
+
+export const TrustpilotBlock: React.FC = () => {
+  const trustpilotRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const castedWindow = window as any
+    if (castedWindow && castedWindow.Trustpilot) {
+      castedWindow.Trustpilot.loadFromElement(trustpilotRef.current, true)
+    }
+  }, [])
+
+  return (
+    <TrustpilotWrapper>
+      <ContextContainer>
+        {({ currentLocale }) => (
+          <div
+            ref={trustpilotRef}
+            className="trustpilot-widget"
+            data-locale={currentLocale.label === 'se' ? 'sv-SE' : 'en-US'}
+            data-template-id="54ad5defc6454f065c28af8b"
+            data-businessunit-id="5b62ebf41788620001d3c4ae"
+            data-style-height="240px"
+            data-style-width="100%"
+            data-theme="light"
+            data-stars="4,5"
+            data-review-languages={
+              currentLocale.htmlLang === 'sv' ? currentLocale.htmlLang : 'en'
+            }
+            data-text-color={colorsV3.gray900}
+          >
+            <a
+              href="https://www.trustpilot.com/review/www.hedvig.com"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Trustpilot
+            </a>
+          </div>
+        )}
+      </ContextContainer>
+    </TrustpilotWrapper>
+  )
+}

--- a/src/blocks/index.tsx
+++ b/src/blocks/index.tsx
@@ -21,6 +21,7 @@ import { QuoteBlockBrandPivot } from './QuoteBlockBrandPivot/QuoteBlockBrandPivo
 import { SingleQuoteBlock } from './SingleQuoteBlock'
 import { SpacerBlock } from './SpacerBlock'
 import { TitleParagraphBlockBrandPivot } from './TitleParagraphBlockBrandPivot/TitleParagraphBlockBrandPivot'
+import { TrustpilotBlock } from './TrustpilotBlock/TrustpilotBlock'
 
 const blockComponents = {
   app_buttons_block: AppButtonsBlock,
@@ -45,6 +46,7 @@ const blockComponents = {
   perils_block: PerilsBlock,
   spacer_block: SpacerBlock,
   spacer_block_brand_pivot: SpacerBlock,
+  trustpilot_block: TrustpilotBlock,
   youtube_video_block: YoutubeVideoBlock,
 }
 

--- a/src/server/page.tsx
+++ b/src/server/page.tsx
@@ -70,6 +70,9 @@ const template = ({
       Sentry.init(${JSON.stringify(sentryConfig())})
     </script>
     <link href="https://fonts.googleapis.com/css?family=EB+Garamond:400,400i&display=swap" rel="stylesheet">
+    <!-- TrustBox script -->
+    <script type="text/javascript" src="//widget.trustpilot.com/bootstrap/v5/tp.widget.bootstrap.min.js" async></script>
+    <!-- End TrustBox script -->
   </head>
   <body>
   <!-- Google Tag Manager (noscript) -->

--- a/storyblok/components.json
+++ b/storyblok/components.json
@@ -2717,6 +2717,20 @@
       "component_group_uuid": null
     },
     {
+      "name": "trustpilot_block",
+      "display_name": null,
+      "schema": {},
+      "image": null,
+      "preview_field": null,
+      "is_root": false,
+      "preview_tmpl": null,
+      "is_nestable": true,
+      "all_presets": [],
+      "preset_id": null,
+      "real_name": "trustpilot_block",
+      "component_group_uuid": null
+    },
+    {
       "name": "youtube_video_block",
       "display_name": null,
       "schema": {


### PR DESCRIPTION
## What?

Added Trustpilot reviews slider. It's an embedded iframe since we don't have the time to build something custom and we want reviews NOW. There's no capabilities to edit the widget in Storyblok right now, we might add this later. If you're on `/se` review will be in Swedish , all other will be in English since we barely have any Norwegian reviews yet. Embed code from here: https://trstp.lt/YH5N4nS_m

Mange & CO will be very happy if we can get this out today 🥳

## Why?

This will be used specifically on campaign pages but on some other pages as well. 

And no, it will not be right here on the startpage :) 

![trutpilotreview](https://user-images.githubusercontent.com/6661511/101885640-ae49b300-3b9a-11eb-97ad-3bf6226f74c8.gif)

