### PR TITLE
Remove mandatory title in image text block

### DIFF
--- a/storyblok/components.json
+++ b/storyblok/components.json
@@ -1527,7 +1527,7 @@
         },
         "title": {
           "type": "text",
-          "required": true,
+          "required": false,
           "default_value": "Default Text",
           "pos": 1,
           "translatable": true


### PR DESCRIPTION
## What?

Remove mandatory title in image text block


## Why?

It used a lot without the need for a title
