### PR TITLE
Remove fill-style from `PerilItem`

### DIFF
--- a/src/components/Perils/PerilItem/PerilItem.tsx
+++ b/src/components/Perils/PerilItem/PerilItem.tsx
@@ -106,10 +106,6 @@ const IconWrapper = styled.div`
     ${TABLET_BP_UP} {
       transform: translateX(-0.625rem);
     }
-
-    path {
-      fill: currentColor;
-    }
   }
 `
 


### PR DESCRIPTION
## What?

Remove fill-style from SVG icon path in `PerilItem`-component.

## Why?

SVG icons control their own color styles.
