### PR TITLE
Update padding in menu to fit more text

### DIFF
--- a/src/blocks/HeaderBlockBrandPivot/MenuItem.tsx
+++ b/src/blocks/HeaderBlockBrandPivot/MenuItem.tsx
@@ -7,7 +7,7 @@ import { Chevron } from 'components/icons/Chevron'
 import { MOBILE_BP_DOWN } from 'components/blockHelpers'
 import { MenuItem as MenuItemType } from '../../storyblok/StoryContainer'
 import { getStoryblokLinkUrl } from '../../utils/storyblok'
-import { TABLET_BP_DOWN, TABLET_BP_UP } from './mobile'
+import { TABLET_BP_DOWN, TABLET_BP_UP, DESKTOP_BP_UP } from './mobile'
 
 const MenuListItem = styled('li')({
   position: 'relative',
@@ -16,6 +16,11 @@ const MenuListItem = styled('li')({
 
   [TABLET_BP_UP]: {
     display: 'flex',
+    paddingLeft: '1rem',
+    paddingRight: '1rem',
+  },
+
+  [DESKTOP_BP_UP]: {
     paddingLeft: '1.5rem',
     paddingRight: '1.5rem',
   },

--- a/src/blocks/HeaderBlockBrandPivot/index.tsx
+++ b/src/blocks/HeaderBlockBrandPivot/index.tsx
@@ -21,7 +21,7 @@ import {
 } from '../BaseBlockProps'
 import { LanguagePicker } from './LanguagePicker'
 import { MenuItem } from './MenuItem'
-import { Burger, TABLET_BP_DOWN, TABLET_BP_UP } from './mobile'
+import { Burger, TABLET_BP_DOWN, TABLET_BP_UP, DESKTOP_BP_UP } from './mobile'
 
 export const WRAPPER_HEIGHT = '5rem'
 export const MOBILE_WRAPPER_HEIGHT = '4.5rem'
@@ -166,7 +166,11 @@ const LogoLink = styled('a')({
 })
 
 const ButtonWrapper = styled('div')({
-  paddingLeft: '3rem',
+  paddingLeft: '2rem',
+
+  [DESKTOP_BP_UP]: {
+    paddingLeft: '3rem',
+  },
 
   [TABLET_BP_DOWN]: {
     paddingTop: '1.5rem',

--- a/src/blocks/HeaderBlockBrandPivot/mobile.tsx
+++ b/src/blocks/HeaderBlockBrandPivot/mobile.tsx
@@ -4,8 +4,9 @@ import React from 'react'
 import { TogglableState } from '../../components/containers/Togglable'
 import { HEADER_VERTICAL_PADDING, TOGGLE_TRANSITION_TIME } from './index'
 
-export const TABLET_BP_DOWN = '@media (max-width: 1000px)'
-export const TABLET_BP_UP = '@media (min-width: 1001px)'
+export const TABLET_BP_DOWN = '@media (max-width: 1023px)'
+export const TABLET_BP_UP = '@media (min-width: 1024px)'
+export const DESKTOP_BP_UP = '@media (min-width: 1280px)'
 
 const BURGER_LINE_WIDTH = '1.5rem'
 

--- a/src/components/ButtonBrandPivot/Button.tsx
+++ b/src/components/ButtonBrandPivot/Button.tsx
@@ -83,6 +83,7 @@ export const ButtonBrandPivot = styled('button')<
       cursor: 'pointer',
       lineHeight: '1rem',
       transition: 'background 150ms, color 150ms',
+      whiteSpace: 'nowrap',
       ...getMinimalButtonTypeStyle(styleType, color),
 
       '&:hover': {


### PR DESCRIPTION
## What?

Increase width for tablet breakpoints.
Add new desktop breakpoint.
Reduce padding in menu to fit more text.
Prevent word wrapping in menu button.

## Why?

The current site doesn't look very nice on e.g. iPad in landscape mode.

I feel like we would benefit from harmonizing breakpoints to a standard (see: https://tailwindcss.com/docs/breakpoints).

## Here's the NO header (has the most text):

https://user-images.githubusercontent.com/1220232/118629840-442edd00-b7ce-11eb-806d-0d656bfdee9e.mov

