### PR TITLE
Update image text block layout/alignment

### DIFF
--- a/src/blocks/ImageTextBlockBrandPivot/index.tsx
+++ b/src/blocks/ImageTextBlockBrandPivot/index.tsx
@@ -40,7 +40,7 @@ interface Animateable {
 const AlignableContentWrapper = styled(ContentWrapper)<{
   textPosition: TextPosition
 }>(({ textPosition }) => ({
-  padding: '0 1rem',
+  padding: '0 2rem',
   display: 'flex',
   position: 'relative',
   flexDirection:
@@ -81,7 +81,7 @@ const TextWrapper = styled('div')<{
   textAlign: textPosition === 'center' ? 'center' : 'left',
   width: '100%',
   ...(textPosition === 'left' && {
-    paddingLeft: isBlockFullWidth ? '4rem' : 0,
+    paddingLeft: 0,
     paddingRight: '4rem',
   }),
   ...(textPosition === 'right' && {

--- a/src/blocks/ImageTextBlockBrandPivot/index.tsx
+++ b/src/blocks/ImageTextBlockBrandPivot/index.tsx
@@ -39,8 +39,9 @@ interface Animateable {
 
 const AlignableContentWrapper = styled(ContentWrapper)<{
   textPosition: TextPosition
-}>(({ textPosition }) => ({
-  padding: '0 2rem',
+  padding?: 'minimal' | 'relaxed'
+}>(({ textPosition, padding }) => ({
+  padding: padding === 'relaxed' ? '0 2rem' : '0 1rem',
   display: 'flex',
   position: 'relative',
   flexDirection:
@@ -317,6 +318,7 @@ export const ImageTextBlockBrandPivot: React.FunctionComponent<ImageTextBlockPro
         index={index}
         brandPivot
         fullWidth={full_width}
+        padding={background_type === 'video' ? 'relaxed' : 'minimal'}
       >
         <TextWrapper
           textPosition={text_position}

--- a/src/components/blockHelpers.tsx
+++ b/src/components/blockHelpers.tsx
@@ -187,7 +187,10 @@ const sectionSizeStyles = {
     },
   },
   xl: {
-    padding: '10rem 0',
+    padding: '10rem 0 3rem',
+    display: 'flex',
+    alignItems: 'flex-end',
+
     [TABLET_BP_DOWN]: {
       padding: '6rem 0',
     },


### PR DESCRIPTION
## What?

Align text in block with menu (left).
Push text content down to bottom for size XL.
Ensure consistent bottom padding.

## Why?

The look of this element no longer matches the intended designs in Figma.

Editors have copy-pasted styles into StoryBlok to force layout changes.

> Menu and Intercom chat bubble are handled in different PRs

> When deploying these changes we also need to update the "extra_styling" in StoryBlok to remove `padding-bottom. It is now handled by the component.

## Mobile: same layout

![Screenshot 2021-05-18 at 16 29 31](https://user-images.githubusercontent.com/1220232/118672495-92f16c80-b7f8-11eb-857a-b723d5c45762.png)

## Tablet: before

![Screenshot 2021-05-18 at 16 30 05](https://user-images.githubusercontent.com/1220232/118672575-a43a7900-b7f8-11eb-813e-4f0724616fc4.png)

## Tablet: after

![Screenshot 2021-05-18 at 16 30 17](https://user-images.githubusercontent.com/1220232/118672611-ad2b4a80-b7f8-11eb-8622-66ea36a6a188.png)

## Desktop: before

![Screenshot 2021-05-18 at 16 31 05](https://user-images.githubusercontent.com/1220232/118672713-bf0ced80-b7f8-11eb-8700-8b1357373f68.png)

## Desktop: after

![Screenshot 2021-05-18 at 16 30 57](https://user-images.githubusercontent.com/1220232/118672876-d9df6200-b7f8-11eb-8139-72393edabd22.png)

## Large desktop: before

![Screenshot 2021-05-18 at 16 31 42](https://user-images.githubusercontent.com/1220232/118673086-04311f80-b7f9-11eb-80dd-a70cf90bef88.png)

## Large desktop: after

![Screenshot 2021-05-18 at 16 31 33](https://user-images.githubusercontent.com/1220232/118673107-085d3d00-b7f9-11eb-9278-7b65c903dc1c.png)
