### PR TITLE
Localised Trustpilot reviews for reals this time

### DIFF
--- a/src/blocks/TrustpilotBlock/TrustpilotBlock.tsx
+++ b/src/blocks/TrustpilotBlock/TrustpilotBlock.tsx
@@ -27,16 +27,17 @@ export const TrustpilotBlock: React.FC = () => {
           <div
             ref={trustpilotRef}
             className="trustpilot-widget"
-            data-locale={currentLocale.label === 'se' ? 'sv-SE' : 'en-US'}
+            data-locale={
+              currentLocale.htmlLang === 'en'
+                ? 'en-US'
+                : currentLocale.iso.replace('_', '-')
+            }
             data-template-id="54ad5defc6454f065c28af8b"
             data-businessunit-id="5b62ebf41788620001d3c4ae"
             data-style-height="240px"
             data-style-width="100%"
             data-theme="light"
-            data-tags="SelectedReview"
-            data-review-languages={
-              currentLocale.htmlLang === 'sv' ? currentLocale.htmlLang : 'en'
-            }
+            data-tags={currentLocale.htmlLang}
             data-text-color={colorsV3.gray900}
           >
             <a

--- a/src/blocks/TrustpilotBlock/TrustpilotBlock.tsx
+++ b/src/blocks/TrustpilotBlock/TrustpilotBlock.tsx
@@ -27,11 +27,7 @@ export const TrustpilotBlock: React.FC = () => {
           <div
             ref={trustpilotRef}
             className="trustpilot-widget"
-            data-locale={
-              currentLocale.htmlLang === 'en'
-                ? 'en-US'
-                : currentLocale.iso.replace('_', '-')
-            }
+            data-locale={currentLocale.trustpilotLocale}
             data-template-id="54ad5defc6454f065c28af8b"
             data-businessunit-id="5b62ebf41788620001d3c4ae"
             data-style-height="240px"

--- a/src/utils/locales.ts
+++ b/src/utils/locales.ts
@@ -15,6 +15,7 @@ export type LocaleData = {
   htmlLang: HtmlLang
   hrefLang: HrefLang
   adtractionSrc?: string
+  trustpilotLocale?: string
 }
 
 export type Locales = Record<Label, LocaleData>
@@ -29,6 +30,7 @@ export const locales: Locales = {
     htmlLang: 'sv',
     hrefLang: 'sv-se',
     adtractionSrc: 'https://cdn.adt387.com/jsTag?ap=1412531808',
+    trustpilotLocale: 'sv-SE',
   },
   'se-en': {
     label: 'se-en',
@@ -39,6 +41,7 @@ export const locales: Locales = {
     htmlLang: 'en',
     hrefLang: 'en-se',
     adtractionSrc: 'https://cdn.adt387.com/jsTag?ap=1412531808',
+    trustpilotLocale: 'en-US',
   },
   no: {
     label: 'no',
@@ -49,6 +52,7 @@ export const locales: Locales = {
     htmlLang: 'no',
     hrefLang: 'no-no',
     adtractionSrc: 'https://cdn.adt387.com/jsTag?ap=1492109567',
+    trustpilotLocale: 'nb-NO',
   },
   'no-en': {
     label: 'no-en',
@@ -59,6 +63,7 @@ export const locales: Locales = {
     htmlLang: 'en',
     hrefLang: 'en-no',
     adtractionSrc: 'https://cdn.adt387.com/jsTag?ap=1492109567',
+    trustpilotLocale: 'en-US',
   },
   dk: {
     label: 'dk',
@@ -68,6 +73,7 @@ export const locales: Locales = {
     langLabel: 'Da',
     htmlLang: 'da',
     hrefLang: 'da-dk',
+    trustpilotLocale: 'da-DK',
   },
   'dk-en': {
     label: 'dk-en',
@@ -77,6 +83,7 @@ export const locales: Locales = {
     langLabel: 'En',
     htmlLang: 'en',
     hrefLang: 'en-dk',
+    trustpilotLocale: 'en-US',
   },
 }
 


### PR DESCRIPTION
## What?

Fetch Trustpilot review based on tags instead. Tags is added manually by Emil in Trustpilot. The tags we use represent the language they are written in `sv, no, da, en` i.e. maps directly to html lang. 
The `data-locale` is the boilerplate text from the widget like dates and such and is written in iso format, however the delimiter is different from our iso unfortunately, so I added an extra property to the `locales` object  


## Why?

Add possibility to show Trustpilot reviews in native languages across the site. Having handpicked reviews as we had before limited us to 15 reviews for all markets.

### Trustpilot widget


https://user-images.githubusercontent.com/6661511/118940231-c9da9600-b950-11eb-9dc4-7c79acbdcfc4.mov

