### PR TITLE
Support standard color for app buttons block

### DIFF
--- a/src/blocks/AppButtonsBlock.tsx
+++ b/src/blocks/AppButtonsBlock.tsx
@@ -1,7 +1,23 @@
 import React from 'react'
 import { AppButtons } from 'components/AppButtons/AppButtons'
 import { ContentWrapper, SectionWrapper } from 'components/blockHelpers'
-import { BrandPivotBaseBlockProps } from './BaseBlockProps'
+import {
+  BrandPivotBaseBlockProps,
+  minimalColorComponentColors,
+} from './BaseBlockProps'
+
+type StandardColor = 'standard' | 'standard-inverse'
+
+const STANDARD_COLORS: Array<minimalColorComponentColors> = [
+  'standard',
+  'standard-inverse',
+]
+
+function isStandardColor(
+  color: minimalColorComponentColors,
+): color is StandardColor {
+  return STANDARD_COLORS.includes(color)
+}
 
 export const AppButtonsBlock: React.FC<BrandPivotBaseBlockProps> = ({
   index,
@@ -15,7 +31,10 @@ export const AppButtonsBlock: React.FC<BrandPivotBaseBlockProps> = ({
     extraStyling={extra_styling}
   >
     <ContentWrapper brandPivot index={index}>
-      <AppButtons alignCenter />
+      <AppButtons
+        alignCenter
+        color={color && isStandardColor(color.color) ? color.color : undefined}
+      />
     </ContentWrapper>
   </SectionWrapper>
 )

--- a/src/blocks/AppButtonsBlock.tsx
+++ b/src/blocks/AppButtonsBlock.tsx
@@ -13,11 +13,9 @@ const STANDARD_COLORS: Array<minimalColorComponentColors> = [
   'standard-inverse',
 ]
 
-function isStandardColor(
+const isStandardColor = (
   color: minimalColorComponentColors,
-): color is StandardColor {
-  return STANDARD_COLORS.includes(color)
-}
+): color is StandardColor => STANDARD_COLORS.includes(color)
 
 export const AppButtonsBlock: React.FC<BrandPivotBaseBlockProps> = ({
   index,


### PR DESCRIPTION
## What?

Pass color option to app buttons to turn them black on white (standard) background.
Add type guard function to keep things type safe. Maybe a bit complicated solution but at least it's type safe - what do you say?

## Why?

App buttons are white on white (standard) background. We are not passing the color option to the buttons component.

## Screenshot: hover vs. not-hover

![Screenshot 2021-05-20 at 15 02 26](https://user-images.githubusercontent.com/1220232/118983667-f5737580-b97c-11eb-8ed9-c9a6ef2a34e5.png)
