### PR TITLE
Localize app store link

### DIFF
--- a/src/components/AppButtons/AppButtons.tsx
+++ b/src/components/AppButtons/AppButtons.tsx
@@ -7,7 +7,7 @@ import { AppStore } from './svg/AppStore'
 import { PlayStore } from './svg/PlayStore'
 
 const localeToAppStoreLink = (locale: LocaleData): string => {
-  return `https://apps.apple.com/${locale.marketLabel}/app/hedvig/id1303668531?l=${locale.htmlLang}`
+  return `https://apps.apple.com/${locale.marketLabel}/app/hedvig/id1303668531?itsct=apps_box_link&itscg=30200`
 }
 
 const BP_UP = '@media (min-width: 375px)'

--- a/src/components/AppButtons/AppButtons.tsx
+++ b/src/components/AppButtons/AppButtons.tsx
@@ -1,8 +1,14 @@
 import styled from '@emotion/styled'
 import React from 'react'
+import { LocaleData } from 'utils/locales'
 import { ButtonLinkBrandPivot } from '../ButtonBrandPivot/Button'
+import { ContextContainer } from '../containers/ContextContainer'
 import { AppStore } from './svg/AppStore'
 import { PlayStore } from './svg/PlayStore'
+
+const localeToAppStoreLink = (locale: LocaleData): string => {
+  return `https://apps.apple.com/${locale.marketLabel}/app/hedvig/id1303668531?l=${locale.htmlLang}`
+}
 
 const BP_UP = '@media (min-width: 375px)'
 
@@ -61,23 +67,31 @@ export const AppButtons: React.FC<AppButtonsProps> = ({
   alignCenter = false,
 }) => {
   return (
-    <ButtonsWrapper center={alignCenter}>
-      <AppButton
-        color={color}
-        styleType="outlined"
-        size="sm"
-        href="https://play.google.com/store/apps/details?id=com.hedvig.app"
-      >
-        <PlayStore />
-      </AppButton>
-      <AppButton
-        color={color}
-        styleType="outlined"
-        size="sm"
-        href="https://apps.apple.com/app/hedvig/id1303668531"
-      >
-        <AppStore />
-      </AppButton>
-    </ButtonsWrapper>
+    <ContextContainer>
+      {({ currentLocale }) => (
+        <ButtonsWrapper center={alignCenter}>
+          <AppButton
+            color={color}
+            styleType="outlined"
+            size="sm"
+            href="https://play.google.com/store/apps/details?id=com.hedvig.app"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <PlayStore />
+          </AppButton>
+          <AppButton
+            color={color}
+            styleType="outlined"
+            size="sm"
+            href={localeToAppStoreLink(currentLocale)}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <AppStore />
+          </AppButton>
+        </ButtonsWrapper>
+      )}
+    </ContextContainer>
   )
 }


### PR DESCRIPTION
## What?

Create localised app button links to App Store.
Treat app button links as external (open in new tab).

## Why?

The current link behaves a little erratic, sometime opening iTunes/App Store.
The new link opens to the web version of the product page (on Desktop).
It also handles opening the link to the relevant market and in the relevant language!

![Screenshot 2021-07-20 at 10 33 29](https://user-images.githubusercontent.com/1220232/126288984-0dd370a4-550c-4399-b319-625494523ee6.png)

_Referenced ticket: [TSEO-2]_


[TSEO-2]: https://hedvig.atlassian.net/browse/TSEO-2