### PR TITLE
Filter out non-public pages from sitemap

### DIFF
--- a/src/server/sitemap.ts
+++ b/src/server/sitemap.ts
@@ -60,6 +60,7 @@ const getSitemapLinks = async (logger: Logger): Promise<ReadonlyArray<Url>> => {
   const sitemapLinks = pages
     .filter(({ url }) => Boolean(url))
     .filter(({ page }) => page?.story?.content?.robots === 'index')
+    .filter(({ page }) => page?.story.content?.public === true)
     .map(({ url }) => ({
       url,
       priority: 0.7,


### PR DESCRIPTION
## Why?

We need a way to exclude Storyblok pages from the sitemap.

As far as I could tell, all pages have the public checkbox enabled. It seems only relevant to exclude the non-public pages from the sitemap so maybe that's all we need.

<!-- If there is one, add the Jira issue ID in brackets below. This will create a link to that issue. -->
_Referenced ticket: [TSEO-19]_


<!-- And, if that makes sense, add screenshots and/or GIF's below -->


[TSEO-19]: https://hedvig.atlassian.net/browse/TSEO-19