### PR TITLE
Get image dimensions from URL

### DIFF
--- a/src/blocks/ImageBlockBrandPivot/ImageBlockBrandPivot.tsx
+++ b/src/blocks/ImageBlockBrandPivot/ImageBlockBrandPivot.tsx
@@ -3,7 +3,11 @@ import React from 'react'
 import { Caption } from 'components/Caption'
 import { ContentWrapper } from '../../components/blockHelpers'
 import { DeferredImage } from '../../components/DeferredImage'
-import { getStoryblokImage, Image as ImageType } from '../../utils/storyblok'
+import {
+  getImageDimensions,
+  getStoryblokImage,
+  Image as ImageType,
+} from '../../utils/storyblok'
 import {
   BrandPivotBaseBlockProps,
   MarkdownHtmlComponent,
@@ -42,7 +46,7 @@ export const ImageBlockBrandPivot: React.FunctionComponent<ImageBlockProps> = ({
     extraStyling={extra_styling}
   >
     <ImageWrapper>
-      <Image src={getStoryblokImage(image)} />
+      <Image src={getStoryblokImage(image)} {...getImageDimensions(image)} />
       {caption && <Caption caption={caption} />}
     </ImageWrapper>
   </StyledContentWrapper>

--- a/src/blocks/ImageTextBlockBrandPivot/index.tsx
+++ b/src/blocks/ImageTextBlockBrandPivot/index.tsx
@@ -23,6 +23,7 @@ import {
 import { DeferredImage } from '../../components/DeferredImage'
 import { DeferredVideo } from '../../components/DeferredVideo'
 import {
+  getImageDimensions,
   getStoryblokImage,
   Image as StoryblokImage,
 } from '../../utils/storyblok'
@@ -391,6 +392,7 @@ export const ImageTextBlockBrandPivot: React.FunctionComponent<ImageTextBlockPro
                       displayorder={media_position}
                       smallImage={media_size_small}
                       src={getStoryblokImage(mobile_image)}
+                      {...getImageDimensions(mobile_image)}
                     />
                   </MediaQuery>
                   <MediaQuery query="(min-width: 481px)">
@@ -399,6 +401,7 @@ export const ImageTextBlockBrandPivot: React.FunctionComponent<ImageTextBlockPro
                       displayorder={media_position}
                       smallImage={media_size_small}
                       src={getStoryblokImage(image)}
+                      {...getImageDimensions(image)}
                     />
                   </MediaQuery>
                 </>
@@ -410,6 +413,7 @@ export const ImageTextBlockBrandPivot: React.FunctionComponent<ImageTextBlockPro
               displayorder={media_position}
               smallImage={media_size_small}
               src={getStoryblokImage(image)}
+              {...getImageDimensions(image)}
             />
           )
         ) : (

--- a/src/utils/storyblok.ts
+++ b/src/utils/storyblok.ts
@@ -34,6 +34,19 @@ export const getStoryblokImage = (url?: Image) =>
       )
     : url
 
+export const getImageDimensions = (
+  url: Image,
+): { width?: number; height?: number } => {
+  const dimensions = url.match(/\b(\d+)x(\d+)\b/)
+
+  if (dimensions === null) return {}
+
+  return {
+    width: parseInt(dimensions[1], 10),
+    height: parseInt(dimensions[2], 10),
+  }
+}
+
 export type Image = string
 export interface NativeColor {
   uuid: string


### PR DESCRIPTION
## What?

Spread width/height on image element if it's part of the asset URL.

## Why?

We want to tell the browser the dimensions of the images to avoid layout shifts.

> QUESTION: I can't work out how to integrate this with the `DeferredImage` component. I'm not really sure why it swaps images on the fly and sets the width/height to undefined.