### PR TITLE
Remove "public" Storyblok field

### DIFF
--- a/src/server/sitemap-test-data.ts
+++ b/src/server/sitemap-test-data.ts
@@ -527,7 +527,6 @@ export const indexedStoryResponse = `
           "extra_styling": ""
         }
       ],
-      "public": true,
       "robots": "index",
       "component": "page",
       "page_title": "Home & Contents Insurance | Help like you never imagined",
@@ -1023,7 +1022,6 @@ export const noindexedStoryResponse = `
           "extra_styling": ""
         }
       ],
-      "public": true,
       "robots": "noindex",
       "component": "page",
       "page_title": "Home & Contents Insurance | Help like you never imagined",

--- a/src/storyblok/StoryContainer.tsx
+++ b/src/storyblok/StoryContainer.tsx
@@ -55,7 +55,6 @@ export interface BodyStory extends Story {
     HrefLang & {
       _uid: string
       page_title: string
-      public: boolean
       component: 'page'
       body: ReadonlyArray<BaseBlockProps>
       hide_footer?: boolean

--- a/storyblok/components.json
+++ b/storyblok/components.json
@@ -2239,11 +2239,6 @@
           "description": "",
           "display_name": ""
         },
-        "public": {
-          "type": "boolean",
-          "translatable": true,
-          "pos": 1
-        },
         "body": {
           "type": "bloks",
           "pos": 2


### PR DESCRIPTION
## What?

Update sitemap test data.
Update Storyblok Story type.

## Why?

This field is no longer used for anything.
Background: https://github.com/HedvigInsurance/market-web/pull/589#issuecomment-891598563