### PR TITLE
Generate structured data rich google results

### DIFF
--- a/src/blocks/AccordionBlock/AccordionBlock.tsx
+++ b/src/blocks/AccordionBlock/AccordionBlock.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled'
 import { Container } from 'constate'
 import React from 'react'
 import AnimateHeight from 'react-animate-height'
+import Helmet from 'react-helmet-async'
 import {
   BrandPivotBaseBlockProps,
   MarkdownHtmlComponent,
@@ -12,8 +13,9 @@ import {
   TABLET_BP_UP,
 } from 'components/blockHelpers'
 import { PlusBrandPivot } from 'components/icons/PlusBrandPivot'
+import { structuredFAQPage } from 'utils/structuredData'
 
-interface AccordionProps {
+export interface AccordionProps {
   _uid: string
   title: string
   paragraph: MarkdownHtmlComponent
@@ -195,5 +197,11 @@ export const AccordionBlock: React.FunctionComponent<AccordionBlockProps> = ({
         )}
       </AccordionsWrapper>
     </ContentWrapper>
+
+    <Helmet>
+      <script type="application/ld+json">
+        {JSON.stringify(structuredFAQPage(accordions))}
+      </script>
+    </Helmet>
   </SectionWrapper>
 )

--- a/src/blocks/AccordionBlock/AccordionBlock.tsx
+++ b/src/blocks/AccordionBlock/AccordionBlock.tsx
@@ -169,6 +169,7 @@ export const Accordion: React.FC<AccordionProps> = ({ title, paragraph }) => (
 export interface AccordionBlockProps extends BrandPivotBaseBlockProps {
   title: string
   accordions: ReadonlyArray<AccordionProps>
+  is_faq?: boolean
 }
 
 export const AccordionBlock: React.FunctionComponent<AccordionBlockProps> = ({
@@ -178,6 +179,7 @@ export const AccordionBlock: React.FunctionComponent<AccordionBlockProps> = ({
   index,
   size,
   title,
+  is_faq = false,
 }) => (
   <SectionWrapper
     brandPivot
@@ -198,10 +200,12 @@ export const AccordionBlock: React.FunctionComponent<AccordionBlockProps> = ({
       </AccordionsWrapper>
     </ContentWrapper>
 
-    <Helmet>
-      <script type="application/ld+json">
-        {JSON.stringify(structuredFAQPage(accordions))}
-      </script>
-    </Helmet>
+    {is_faq && (
+      <Helmet>
+        <script type="application/ld+json">
+          {JSON.stringify(structuredFAQPage(accordions))}
+        </script>
+      </Helmet>
+    )}
   </SectionWrapper>
 )

--- a/src/pages/StoryPage.tsx
+++ b/src/pages/StoryPage.tsx
@@ -4,7 +4,11 @@ import SbEditable from 'patched/storyblok-react'
 import { getBlockComponent } from '../blocks'
 import { BaseBlockProps } from '../blocks/BaseBlockProps'
 import { FooterBlock } from '../blocks/FooterBlock/FooterBlock'
-import { BodyStory, StoryContainer } from '../storyblok/StoryContainer'
+import {
+  BodyStory,
+  GlobalStoryContainer,
+  StoryContainer,
+} from '../storyblok/StoryContainer'
 import { getMeta } from '../utils/meta'
 import { ContextContainer } from '../components/containers/ContextContainer'
 
@@ -17,11 +21,17 @@ export const StoryPage: React.FunctionComponent<{ nonce?: string }> = ({
   <StoryContainer<BodyStory>>
     {({ story }) => (
       <>
-        <ContextContainer>
-          {({ currentLocale }) => (
-            <Helmet>{getMeta({ story, nonce, currentLocale })}</Helmet>
+        <GlobalStoryContainer>
+          {({ globalStory }) => (
+            <ContextContainer>
+              {({ currentLocale }) => (
+                <Helmet>
+                  {getMeta({ story, nonce, currentLocale, globalStory })}
+                </Helmet>
+              )}
+            </ContextContainer>
           )}
-        </ContextContainer>
+        </GlobalStoryContainer>
         {getBlocksOrDefault(story!).map((block, index) => {
           const BlockComponent:
             | React.ComponentType<BaseBlockProps & any>

--- a/src/storyblok/StoryContainer.tsx
+++ b/src/storyblok/StoryContainer.tsx
@@ -108,6 +108,8 @@ export interface GlobalStory extends Story {
     peril_modal_exceptions_title?: string
     four_oh_four_title?: string
     cookie_consent_message: MarkdownHtmlComponent
+    structured_data_website_description?: string
+    structured_data_organization_description?: string
   }
 }
 

--- a/src/utils/meta.tsx
+++ b/src/utils/meta.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import {
-  GlobalStoryContainer,
+  GlobalStory,
   HrefLang,
   SeoContent,
   Story,
@@ -19,6 +19,7 @@ interface Meta {
   fullSlug?: string
   title?: string
   currentLocale?: LocaleData
+  globalStory: GlobalStory
 }
 
 const removeTrailingSlash = (text: string) => text.replace(/\/+$/, '')
@@ -45,25 +46,21 @@ export const getMeta = ({
   nonce = '',
   fullSlug,
   currentLocale,
+  globalStory,
 }: Meta) => (
   <>
-    <GlobalStoryContainer>
-      {({ globalStory }) => (
-        <script type="application/ld+json" nonce={nonce} key="jsonld">
-          {JSON.stringify([
-            structuredWebSite({
-              description:
-                globalStory.content.structured_data_website_description,
-            }),
-            structuredOrganization({
-              description:
-                globalStory.content.structured_data_organization_description,
-            }),
-            ...structuredSoftwareApplication(),
-          ])}
-        </script>
-      )}
-    </GlobalStoryContainer>
+    <script type="application/ld+json" nonce={nonce} key="jsonld">
+      {JSON.stringify([
+        structuredWebSite({
+          description: globalStory.content.structured_data_website_description,
+        }),
+        structuredOrganization({
+          description:
+            globalStory.content.structured_data_organization_description,
+        }),
+        ...structuredSoftwareApplication(),
+      ])}
+    </script>
 
     <title>{title ? title : getPageTitleFromStory(story)}</title>
     <link

--- a/src/utils/meta.tsx
+++ b/src/utils/meta.tsx
@@ -1,5 +1,10 @@
 import React from 'react'
-import { HrefLang, SeoContent, Story } from '../storyblok/StoryContainer'
+import {
+  GlobalStoryContainer,
+  HrefLang,
+  SeoContent,
+  Story,
+} from '../storyblok/StoryContainer'
 import { getLocaleData, LocaleData } from './locales'
 import { getPublicHost, getStoryblokImage } from './storyblok'
 import {
@@ -42,13 +47,23 @@ export const getMeta = ({
   currentLocale,
 }: Meta) => (
   <>
-    <script type="application/ld+json" nonce={nonce} key="jsonld">
-      {JSON.stringify([
-        structuredWebSite(),
-        structuredOrganization(),
-        ...structuredSoftwareApplication(),
-      ])}
-    </script>
+    <GlobalStoryContainer>
+      {({ globalStory }) => (
+        <script type="application/ld+json" nonce={nonce} key="jsonld">
+          {JSON.stringify([
+            structuredWebSite({
+              description:
+                globalStory.content.structured_data_website_description,
+            }),
+            structuredOrganization({
+              description:
+                globalStory.content.structured_data_organization_description,
+            }),
+            ...structuredSoftwareApplication(),
+          ])}
+        </script>
+      )}
+    </GlobalStoryContainer>
 
     <title>{title ? title : getPageTitleFromStory(story)}</title>
     <link

--- a/src/utils/meta.tsx
+++ b/src/utils/meta.tsx
@@ -2,6 +2,11 @@ import React from 'react'
 import { HrefLang, SeoContent, Story } from '../storyblok/StoryContainer'
 import { getLocaleData, LocaleData } from './locales'
 import { getPublicHost, getStoryblokImage } from './storyblok'
+import {
+  structuredOrganization,
+  structuredSoftwareApplication,
+  structuredWebSite,
+} from './structuredData'
 
 interface Meta {
   story?: Story & { content: SeoContent & HrefLang }
@@ -37,41 +42,14 @@ export const getMeta = ({
   currentLocale,
 }: Meta) => (
   <>
-    {[
-      <script type="application/ld+json" nonce={nonce} key="jsonld">
-        {`
-[
-  {
-    "name": "Hedvig",
-    "@context": "http://schema.org",
-    "@type": "WebSite",
-    "url": "https://www.hedvig.com",
-    "description": "Hedvig är en ny typ av försäkring. Byggd på smart teknik, omtanke och sunt förnuft. Så att du kan få hjälp på sekunder, och ersättning på minuter."
-  },
-  {
-    "@context": "http://schema.org",
-    "@type": "Organization",
-    "url": "https://www.hedvig.com",
-    "logo": "https://www.hedvig.com/assets-next/favicons/apple-icon.png",
-    "name": "Hedvig",
-    "description": "Med Hedvig Hemförsäkring får du allt du förväntar dig av en försäkring, men inget du förväntar dig av ett försäkringsbolag",
-    "address": {
-      "@type": "PostalAddress",
-      "streetAddress": "Valhallavägen 117",
-      "addressLocality": "Stockholm",
-      "postalCode": "115 31",
-      "addressCountry": "SE"
-    },
-    "sameAs": [
-      "https://www.fb.me/hedvigapp/",
-      "https://twitter.com/hedvigapp",
-      "https://www.instagram.com/hedvig/",
-      "https://www.linkedin.com/company/hedvig/"
-    ]
-  }
-]`}
-      </script>,
-    ]}
+    <script type="application/ld+json" nonce={nonce} key="jsonld">
+      {JSON.stringify([
+        structuredWebSite(),
+        structuredOrganization(),
+        ...structuredSoftwareApplication(),
+      ])}
+    </script>
+
     <title>{title ? title : getPageTitleFromStory(story)}</title>
     <link
       rel="canonical"

--- a/src/utils/structuredData.ts
+++ b/src/utils/structuredData.ts
@@ -1,0 +1,75 @@
+import { AccordionProps } from 'blocks/AccordionBlock/AccordionBlock'
+
+export const structuredFAQPage = (
+  accordions: ReadonlyArray<AccordionProps>,
+) => ({
+  '@context': 'http://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: accordions.map((item) => ({
+    '@type': 'Question',
+    name: item.title,
+    acceptedAnswer: {
+      '@type': 'Answer',
+      text: item.paragraph.html,
+    },
+  })),
+})
+
+export const structuredSoftwareApplication = () => [
+  {
+    '@context': 'http://schema.org',
+    '@type': 'SoftwareApplication',
+    name: 'Hedvig',
+    operatingSystem: 'IOS',
+    applicationCategory: 'FinanceApplication',
+    aggregateRating: {
+      '@type': 'AggregateRating',
+      ratingValue: '4.7',
+      ratingCount: '1200',
+    },
+  },
+  {
+    '@context': 'http://schema.org',
+    '@type': 'SoftwareApplication',
+    name: 'Hedvig',
+    operatingSystem: 'ANDROID',
+    applicationCategory: 'FinanceApplication',
+    aggregateRating: {
+      '@type': 'AggregateRating',
+      ratingValue: '4.4',
+      ratingCount: '180',
+    },
+  },
+]
+
+export const structuredWebSite = () => ({
+  '@context': 'http://schema.org',
+  '@type': 'WebSite',
+  name: 'Hedvig',
+  url: 'https://www.hedvig.com',
+  description:
+    'Hedvig är en ny typ av försäkring. Byggd på smart teknik, omtanke och sunt förnuft. Så att du kan få hjälp på sekunder, och ersättning på minuter.',
+})
+
+export const structuredOrganization = () => ({
+  '@context': 'http://schema.org',
+  '@type': 'Organization',
+  name: 'Hedvig',
+  url: 'https://www.hedvig.com',
+  logo: 'https://www.hedvig.com/assets-next/favicons/apple-icon.png',
+  description:
+    'Med Hedvig Hemförsäkring får du allt du förväntar dig av en försäkring, men inget du förväntar dig av ett försäkringsbolag',
+  address: {
+    '@type': 'PostalAddress',
+    streetAddress: 'Valhallavägen 117',
+    addressLocality: 'Stockholm',
+    postalCode: '115 31',
+    addressCountry: 'SE',
+  },
+  sameAs: [
+    'https://www.fb.me/hedvigapp/',
+    'https://twitter.com/hedvigapp',
+    'https://www.instagram.com/hedvig/',
+    'https://www.linkedin.com/company/hedvig/',
+  ],
+})

--- a/src/utils/structuredData.ts
+++ b/src/utils/structuredData.ts
@@ -1,5 +1,11 @@
 import { AccordionProps } from 'blocks/AccordionBlock/AccordionBlock'
 
+const DEFAULT_WEBSITE_DESCRIPTION =
+  'Hedvig är en ny typ av försäkring. Byggd på smart teknik, omtanke och sunt förnuft. Så att du kan få hjälp på sekunder, och ersättning på minuter.'
+
+const DEFAULT_ORG_DESCRIPTION =
+  'Med Hedvig Hemförsäkring får du allt du förväntar dig av en försäkring, men inget du förväntar dig av ett försäkringsbolag'
+
 export const structuredFAQPage = (
   accordions: ReadonlyArray<AccordionProps>,
 ) => ({
@@ -42,23 +48,33 @@ export const structuredSoftwareApplication = () => [
   },
 ]
 
-export const structuredWebSite = () => ({
+interface StructuredWebSiteParams {
+  description?: string
+}
+
+export const structuredWebSite = ({
+  description = DEFAULT_WEBSITE_DESCRIPTION,
+}: StructuredWebSiteParams = {}) => ({
   '@context': 'http://schema.org',
   '@type': 'WebSite',
   name: 'Hedvig',
   url: 'https://www.hedvig.com',
-  description:
-    'Hedvig är en ny typ av försäkring. Byggd på smart teknik, omtanke och sunt förnuft. Så att du kan få hjälp på sekunder, och ersättning på minuter.',
+  description,
 })
 
-export const structuredOrganization = () => ({
+interface StructuredOrganizationParams {
+  description?: string
+}
+
+export const structuredOrganization = ({
+  description = DEFAULT_ORG_DESCRIPTION,
+}: StructuredOrganizationParams = {}) => ({
   '@context': 'http://schema.org',
   '@type': 'Organization',
   name: 'Hedvig',
   url: 'https://www.hedvig.com',
   logo: 'https://www.hedvig.com/assets-next/favicons/apple-icon.png',
-  description:
-    'Med Hedvig Hemförsäkring får du allt du förväntar dig av en försäkring, men inget du förväntar dig av ett försäkringsbolag',
+  description,
   address: {
     '@type': 'PostalAddress',
     streetAddress: 'Valhallavägen 117',

--- a/storyblok/components.json
+++ b/storyblok/components.json
@@ -610,44 +610,44 @@
         },
         "footer_menu_items": {
           "type": "bloks",
-          "pos": 12,
+          "pos": 6,
           "maximum": "4",
           "restrict_components": true,
           "component_whitelist": ["menu_item"]
         },
         "footer_download_title": {
           "type": "text",
-          "pos": 13
+          "pos": 7
         },
         "footer_safety_title": {
           "type": "text",
-          "pos": 14
+          "pos": 8
         },
         "footer_safety_body": {
           "type": "custom",
-          "pos": 15,
+          "pos": 9,
           "field_type": "markdown-html",
           "options": []
         },
         "footer_rating_title": {
           "type": "text",
-          "pos": 16
+          "pos": 10
         },
         "footer_rating_paragraph": {
           "type": "custom",
-          "pos": 17,
+          "pos": 11,
           "field_type": "markdown-html",
           "options": []
         },
         "footer_market_title": {
           "type": "text",
-          "pos": 18
+          "pos": 12
         },
         "footer_paragraph": {
           "type": "custom",
           "field_type": "markdown-html",
           "options": [],
-          "pos": 19,
+          "pos": 13,
           "translatable": true
         },
         "perils": {
@@ -659,33 +659,58 @@
           ],
           "restrict_components": true,
           "component_whitelist": ["peril_labels"],
-          "pos": 20
+          "pos": 14
         },
         "peril_modal_info_title": {
           "type": "text",
-          "pos": 21
+          "pos": 15
         },
         "peril_modal_coverage_title": {
           "type": "text",
-          "pos": 22
+          "pos": 16
         },
         "peril_modal_exceptions_title": {
           "type": "text",
-          "pos": 23
+          "pos": 17
         },
         "locale": {
           "type": "section",
-          "keys": ["four_oh_four_title", "cookie_consent_message"]
+          "keys": ["four_oh_four_title", "cookie_consent_message"],
+          "pos": 18
         },
         "four_oh_four_title": {
-          "type": "text"
+          "type": "text",
+          "pos": 19
         },
         "cookie_consent_message": {
           "type": "custom",
           "required": true,
           "translatable": true,
           "field_type": "markdown-html",
-          "options": []
+          "options": [],
+          "pos": 20
+        },
+        "structured_data": {
+          "type": "section",
+          "pos": 21,
+          "keys": [
+            "structured_data_website_description",
+            "structured_data_organization_description"
+          ]
+        },
+        "structured_data_website_description": {
+          "type": "text",
+          "pos": 22,
+          "max_length": "",
+          "description": "Description used in structured data \"WebSite\" type for rich search results.",
+          "display_name": "WebSite Description",
+          "default_value": ""
+        },
+        "structured_data_organization_description": {
+          "type": "text",
+          "pos": 23,
+          "display_name": "Organization Description",
+          "description": "Description used in structured data \"Organization\" type for rich search results."
         }
       },
       "image": null,

--- a/storyblok/components.json
+++ b/storyblok/components.json
@@ -63,6 +63,11 @@
           "display_name": "Styling",
           "keys": ["size", "color", "extra_styling"],
           "pos": 5
+        },
+        "is_faq": {
+          "type": "boolean",
+          "description": "Mark as an FAQ block. Will mark it up using structured data for SEO purposes.",
+          "display_name": "Mark as FAQ"
         }
       },
       "image": null,


### PR DESCRIPTION
## What?

Implement FAQPage module for Accordion blocks.
Clean up structured data implementation.
Add SoftwareApplication module.

## Why?

We want to stand out in the search results.

We currently add this from GTM but that's not so manageable so we should do it dynamically here instead.

Reference: https://neilpatel.com/blog/get-started-using-schema/

_Referenced ticket: [TSEO-16]_

[TSEO-16]: https://hedvig.atlassian.net/browse/TSEO-16

## Questions

I'm not 100% if we should include the `SoftwareApplication` module. What do you guys think? Perhaps it only makes sense on the front page.

## Caveats

I noticed that existing structured data is not localised -- we should fix this but I think it would be better to tackle that in a separate PR.

## More

This might be something to look into later: https://github.com/google/react-schemaorg
Try how it works here: https://search.google.com/test/rich-results?utm_campaign=devsite&utm_medium=microdata&utm_source=faq-page