### PR TITLE
GRW-399 Add support for grouping submenus in header

### DIFF
--- a/src/storyblok/StoryContainer.tsx
+++ b/src/storyblok/StoryContainer.tsx
@@ -78,6 +78,13 @@ export interface MenuItem {
   link: LinkComponent
   component: 'menu_item'
   menu_items?: ReadonlyArray<MenuItem>
+  menu_item_groups?: ReadonlyArray<MenuItemGroup>
+}
+
+export interface MenuItemGroup {
+  _uid: string
+  label: string
+  menu_items: ReadonlyArray<MenuItem>
 }
 
 export interface GlobalStory extends Story {

--- a/src/utils/storybook.ts
+++ b/src/utils/storybook.ts
@@ -88,6 +88,57 @@ const headerMenuItems: MenuItem[] = [
   },
   {
     _uid: '4',
+    label: 'Våra Försäkringar',
+    link,
+    component: 'menu_item',
+    menu_item_groups: [
+      {
+        _uid: '1',
+        label: 'Hemförsäkringar',
+        menu_items: [
+          {
+            _uid: '11',
+            label: 'Hyresrätt & Andrahand',
+            link,
+            component: 'menu_item',
+          },
+          {
+            _uid: '12',
+            label: 'Bostadsrätt',
+            link,
+            component: 'menu_item',
+          },
+          {
+            _uid: '13',
+            label: 'Student',
+            link,
+            component: 'menu_item',
+          },
+          {
+            _uid: '14',
+            label: 'Villa',
+            link,
+            component: 'menu_item',
+          },
+        ],
+      },
+
+      {
+        _uid: '2',
+        label: 'Tillval',
+        menu_items: [
+          {
+            _uid: '15',
+            label: 'Olycksfallsförsäkring',
+            link,
+            component: 'menu_item',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    _uid: '5',
     label: 'Om Hedvig',
     link,
     component: 'menu_item',

--- a/storyblok/components.json
+++ b/storyblok/components.json
@@ -2263,16 +2263,51 @@
           "component_whitelist": ["menu_item"],
           "display_name": "Sub menu items",
           "pos": 2
+        },
+        "menu_item_groups": {
+          "type": "bloks",
+          "restrict_components": true,
+          "component_whitelist": ["menu_item_group"],
+          "display_name": "Sub Menu Groups"
         }
       },
       "image": null,
       "preview_field": null,
       "is_root": false,
       "preview_tmpl": null,
-      "is_nestable": false,
+      "is_nestable": true,
       "all_presets": [],
       "preset_id": null,
       "real_name": "menu_item",
+      "component_group_uuid": null
+    },
+    {
+      "name": "menu_item_group",
+      "display_name": null,
+      "schema": {
+        "label": {
+          "type": "text",
+          "required": true,
+          "pos": 0,
+          "translatable": false
+        },
+        "menu_items": {
+          "type": "bloks",
+          "translatable": true,
+          "restrict_components": true,
+          "component_whitelist": ["menu_item"],
+          "display_name": "Group menu items",
+          "pos": 2
+        }
+      },
+      "image": null,
+      "preview_field": null,
+      "is_root": false,
+      "preview_tmpl": null,
+      "is_nestable": true,
+      "all_presets": [],
+      "preset_id": null,
+      "real_name": "menu_item_group",
       "component_group_uuid": null
     },
     {


### PR DESCRIPTION
_Referenced ticket: [GRW-399]_

## What & Why
Adds support for grouping header sub-menu items. They are displayed as columns on desktop and as lists on mobile.
Allows to split insurances into two types: Home & Other. This is in preparation for adding the accident insurance in Sweden.

## Implementation
* Multi-group support is available in case we need more groups in the future (even if that may not look that great on desktop)
* This is backwards compatible, keeping support for ungrouped sub-menus.
* The screenshot below shows an example of how to set the new menu structure in Storyblok
![Setup on Storyblok](https://user-images.githubusercontent.com/89857278/132359653-775d577e-dbe9-4a14-93a8-fdcf0d49fbbe.png)

## Demo
![Screenshot 2021-09-08 at 10 49 10](https://user-images.githubusercontent.com/89857278/132481005-84fdbaea-bb29-4d98-ad5b-f9bc333b1b67.png)
![Screenshot 2021-09-08 at 10 48 56](https://user-images.githubusercontent.com/89857278/132481047-8297ad0a-cecd-4aeb-ab89-b7e55919064e.png)


[GRW-399]: https://hedvig.atlassian.net/browse/GRW-399