### PR TITLE
Set default APP_ENVIRONMENT

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,6 +7,7 @@
     "STORYBLOK_MANAGEMENT_TOKEN": {
       "required": true
     },
+    "APP_ENVIRONMENT": "development",
     "AUTH_NAME": {
       "required": true
     },


### PR DESCRIPTION
## What?
Set default APP_ENVIRONMENT

## Why?
To prevent the app from crashing if it is missing in Heroku
