### PR TITLE
GRW-401 Add support for top banner

### DIFF
--- a/src/blocks/HeaderBlockBrandPivot/Banner.tsx
+++ b/src/blocks/HeaderBlockBrandPivot/Banner.tsx
@@ -1,0 +1,38 @@
+import styled from '@emotion/styled'
+import React from 'react'
+import {
+  ColorComponent,
+  MarkdownHtmlComponent,
+} from 'src/blocks/BaseBlockProps'
+import {
+  CONTENT_MAX_WIDTH_DEPRECATED,
+  SectionWrapper,
+  TABLET_BP_UP,
+} from '../../components/blockHelpers'
+
+const BannerContent = styled('div')({
+  marginLeft: 'auto',
+  marginRight: 'auto',
+  padding: '0.5rem',
+  textAlign: 'center',
+  fontSize: '0.88rem',
+  ...CONTENT_MAX_WIDTH_DEPRECATED,
+
+  [TABLET_BP_UP]: {
+    fontSize: '1rem',
+  },
+
+  '& > *': {
+    marginTop: '0',
+    marginBottom: '0',
+  },
+})
+
+export const Banner: React.FC<{
+  text: MarkdownHtmlComponent
+  color?: ColorComponent
+}> = ({ color, text }) => (
+  <SectionWrapper colorComponent={color} size="none">
+    <BannerContent dangerouslySetInnerHTML={{ __html: text?.html }} />
+  </SectionWrapper>
+)

--- a/src/blocks/HeaderBlockBrandPivot/HeaderBlock.stories.tsx
+++ b/src/blocks/HeaderBlockBrandPivot/HeaderBlock.stories.tsx
@@ -107,3 +107,52 @@ export const WithHero = () => (
     </div>
   </Provider>
 )
+
+export const WithHeroAndBanner = () => (
+  <Provider initialState={{ context: { currentLocale: fallbackLocale } }}>
+    <div>
+      <Header
+        {...headerBaseProps}
+        story={{
+          ...globalStoryMock,
+          content: { ...globalStoryMock.content, show_banner: true },
+        }}
+        is_transparent={boolean('Is Transparent', true)}
+        inverse_colors={boolean(
+          'Inverse Colors (transparent header only)',
+          true,
+        )}
+        cta_color={
+          minimalColorMap[
+            select(
+              'CTA color',
+              Object.keys(minimalColorMap),
+              'standard-inverse',
+            )
+          ]
+        }
+        cta_style={select(
+          'CTA style',
+          ['outlined', 'filled', 'plain'],
+          'outlined',
+        )}
+      />
+      <HeroBlock
+        _uid="1234"
+        component="hero"
+        color={minimalColorMap['standard-inverse']}
+        headline="Hjälp så som du aldrig kunnat <br/>föreställa dig den"
+        headline_font_size="md"
+        image="https://res.cloudinary.com/gustaveen-com/image/upload/q_40/v1589550685/hus_villa_z07bvi.jpg"
+        image_mobile=""
+        hide_bg_tint={false}
+        show_cta={true}
+        cta_label="Läs mer"
+        cta_style="outlined"
+        cta_color={minimalColorMap['standard-inverse']}
+        cta_link={link}
+      />
+      <ScrollContainer />
+    </div>
+  </Provider>
+)

--- a/src/blocks/HeaderBlockBrandPivot/index.tsx
+++ b/src/blocks/HeaderBlockBrandPivot/index.tsx
@@ -22,6 +22,7 @@ import {
 import { LanguagePicker } from './LanguagePicker'
 import { MenuItem } from './MenuItem'
 import { Burger, TABLET_BP_DOWN, TABLET_BP_UP, DESKTOP_BP_UP } from './mobile'
+import { Banner } from './Banner'
 
 export const WRAPPER_HEIGHT = '5rem'
 export const MOBILE_WRAPPER_HEIGHT = '4.5rem'
@@ -34,7 +35,8 @@ const isBelowScrollThreshold = () =>
 const HeaderWrapper = styled('header')<{
   inverse: boolean
 }>(({ inverse }) => ({
-  position: 'relative',
+  position: 'sticky',
+  top: 0,
   zIndex: 100,
   color: inverse ? colorsV3.gray100 : colorsV3.gray900,
   transition: 'color 300ms',
@@ -49,7 +51,7 @@ const HeaderMain = styled('div')<{
   open: boolean
   sticky: boolean
 }>(({ inverse, open }) => ({
-  position: 'fixed',
+  position: 'absolute',
   top: 0,
   left: 0,
   width: '100%',
@@ -219,6 +221,7 @@ interface HeaderBlockProps extends BaseBlockProps {
   cta_color?: MinimalColorComponent
   cta_style?: ButtonStyleType
   hide_menu?: boolean
+  hide_global_banner?: boolean
   override_mobile_header_cta_label?: string | null
   override_mobile_header_cta_link?: LinkComponent | null
   mobile_header_cta_color?: MinimalColorComponent
@@ -233,6 +236,11 @@ enum InverseColors {
 export const Header: React.FC<{ story: GlobalStory } & HeaderBlockProps> = (
   props,
 ) => {
+  const showBanner =
+    props.story.content.show_banner &&
+    props.story.content.banner_text &&
+    !props.hide_global_banner
+
   const { currentLocale } = useLocale()
   const [isBelowThreshold, setIsBelowThreshold] = useState<boolean>(false)
   const [buttonColor, setButtonColor] = useState<
@@ -272,6 +280,12 @@ export const Header: React.FC<{ story: GlobalStory } & HeaderBlockProps> = (
 
   return (
     <>
+      {showBanner && (
+        <Banner
+          color={props.story.content.banner_color}
+          text={props.story.content.banner_text}
+        />
+      )}
       <HeaderWrapper
         inverse={
           props.is_transparent && props.inverse_colors && !isBelowThreshold
@@ -421,7 +435,7 @@ export const Header: React.FC<{ story: GlobalStory } & HeaderBlockProps> = (
   )
 }
 
-export const HeaderBlockBrandPivot: React.FunctionComponent<HeaderBlockProps> = (
+export const HeaderBlock: React.FunctionComponent<HeaderBlockProps> = (
   headerBlockProps,
 ) => (
   <GlobalStoryContainer>

--- a/src/blocks/index.tsx
+++ b/src/blocks/index.tsx
@@ -11,7 +11,7 @@ import { BannerBlock } from './BannerBlock/BannerBlock'
 import { BaseBlockProps } from './BaseBlockProps'
 import { BulletPointBlockBrandPivot } from './BulletPointBlockBrandPivot'
 import { CtaBlock } from './CtaBlock/CtaBlock'
-import { HeaderBlockBrandPivot } from './HeaderBlockBrandPivot'
+import { HeaderBlock } from './HeaderBlockBrandPivot'
 import { HeadlineBlock } from './HeadlineBlock/HeadlineBlock'
 import { ImageBlockBrandPivot } from './ImageBlockBrandPivot/ImageBlockBrandPivot'
 import { InsuranceInfoBlock } from './InsuranceInfoBlock/InsuranceInfoBlock'
@@ -25,7 +25,7 @@ import { TrustpilotBlock } from './TrustpilotBlock/TrustpilotBlock'
 
 const blockComponents = {
   app_buttons_block: AppButtonsBlock,
-  header_block_brand_pivot: HeaderBlockBrandPivot,
+  header_block_brand_pivot: HeaderBlock,
   accordion_block: AccordionBlock,
   accordion_block_brand_pivot: AccordionBlock,
   banner_block: BannerBlock,

--- a/src/pages/FourOhFour.tsx
+++ b/src/pages/FourOhFour.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { withRouter } from 'react-router-dom'
 import { FooterBlock } from 'blocks/FooterBlock/FooterBlock'
-import { HeaderBlockBrandPivot } from 'blocks/HeaderBlockBrandPivot'
+import { HeaderBlock } from '../blocks/HeaderBlockBrandPivot'
 import { FourOhFourBlock } from '../blocks/FourOhFourBlock'
 
 export const FourOhFourPage: React.ComponentType = withRouter(
@@ -11,7 +11,7 @@ export const FourOhFourPage: React.ComponentType = withRouter(
     }
     return (
       <>
-        <HeaderBlockBrandPivot
+        <HeaderBlock
           is_transparent={true}
           inverse_colors={true}
           _uid="header"

--- a/src/storyblok/StoryContainer.tsx
+++ b/src/storyblok/StoryContainer.tsx
@@ -1,6 +1,10 @@
 import { Container } from 'constate'
 import React, { PureComponent } from 'react'
-import { BaseBlockProps, MarkdownHtmlComponent } from '../blocks/BaseBlockProps'
+import {
+  BaseBlockProps,
+  ColorComponent,
+  MarkdownHtmlComponent,
+} from '../blocks/BaseBlockProps'
 import { ErrorBlock } from '../components/blockHelpers'
 import { Image } from '../utils/storyblok'
 
@@ -85,6 +89,9 @@ export interface GlobalStory extends Story {
     _uid: string
     page_title: string // NOT USED
     component: 'global'
+    show_banner: boolean
+    banner_text: MarkdownHtmlComponent
+    banner_color?: ColorComponent
     header_menu_items?: ReadonlyArray<MenuItem>
     show_cta: boolean
     cta_label: string

--- a/src/utils/storybook.ts
+++ b/src/utils/storybook.ts
@@ -2,6 +2,7 @@ import { FontSizes } from 'components/Heading/Heading'
 import {
   MarkdownHtmlComponent,
   MinimalColorComponent,
+  ColorComponent,
 } from 'src/blocks/BaseBlockProps'
 import {
   GlobalStory,
@@ -271,6 +272,21 @@ const cookie_consent_message: MarkdownHtmlComponent = {
   plugin: 'markdown-html',
 }
 
+const exampleBannerText: MarkdownHtmlComponent = {
+  _uid: '1234',
+  html:
+    '<p><strong>Corona-viruset – <a href="https://www.hedvig.com/blog/coronaviruset">så fungerar din försäkring</a></strong></p>',
+  original:
+    '<p><strong>Corona-viruset – <a href="https://www.hedvig.com/blog/coronaviruset">så fungerar din försäkring</a></strong></p>',
+  plugin: 'markdown-html',
+}
+
+const bannerColor: ColorComponent = {
+  _uid: '6ecde11d-ba0a-48fb-9b7b-e6dbf31415d9',
+  color: 'off-black-dark',
+  plugin: 'hedvig_limited_color_picker',
+}
+
 export const globalStoryMock: GlobalStory = {
   name: 'storybook mock',
   created_at: '',
@@ -285,6 +301,9 @@ export const globalStoryMock: GlobalStory = {
     page_title: '',
     component: 'global',
     header_menu_items: headerMenuItems,
+    show_banner: false,
+    banner_text: exampleBannerText,
+    banner_color: bannerColor,
     show_cta: true,
     cta_label: 'Beräkna ditt pris',
     cta_link: link,

--- a/storyblok/components.json
+++ b/storyblok/components.json
@@ -565,9 +565,34 @@
       "name": "global",
       "display_name": null,
       "schema": {
+        "banner": {
+          "type": "section",
+          "pos": 0,
+          "display_name": "Top Banner",
+          "keys": ["show_banner", "banner_text", "banner_color"]
+        },
+        "show_banner": {
+          "type": "boolean",
+          "pos": 1,
+          "display_name": "Enable"
+        },
+        "banner_text": {
+          "type": "custom",
+          "field_type": "markdown-html",
+          "options": [],
+          "pos": 2,
+          "display_name": "Text",
+          "description": ""
+        },
+        "banner_color": {
+          "type": "custom",
+          "pos": 3,
+          "field_type": "hedvig-minimal-color-picker",
+          "options": []
+        },
         "header_menu_items": {
           "type": "bloks",
-          "pos": 0,
+          "pos": 4,
           "maximum": "",
           "restrict_components": true,
           "component_whitelist": ["menu_item"],
@@ -577,22 +602,22 @@
         "cta": {
           "type": "section",
           "keys": ["show_cta", "cta_branch_link", "cta_label", "cta_link"],
-          "pos": 1
+          "pos": 5
         },
         "show_cta": {
           "type": "boolean",
-          "pos": 2,
+          "pos": 6,
           "translatable": true
         },
         "cta_label": {
           "type": "text",
-          "pos": 3,
+          "pos": 7,
           "translatable": true
         },
         "cta_link": {
           "type": "multilink",
           "translatable": true,
-          "pos": 4
+          "pos": 8
         },
         "footer": {
           "type": "section",
@@ -606,48 +631,48 @@
             "footer_market_title",
             "footer_paragraph"
           ],
-          "pos": 5
+          "pos": 9
         },
         "footer_menu_items": {
           "type": "bloks",
-          "pos": 6,
+          "pos": 10,
           "maximum": "4",
           "restrict_components": true,
           "component_whitelist": ["menu_item"]
         },
         "footer_download_title": {
           "type": "text",
-          "pos": 7
+          "pos": 11
         },
         "footer_safety_title": {
           "type": "text",
-          "pos": 8
+          "pos": 12
         },
         "footer_safety_body": {
           "type": "custom",
-          "pos": 9,
+          "pos": 13,
           "field_type": "markdown-html",
           "options": []
         },
         "footer_rating_title": {
           "type": "text",
-          "pos": 10
+          "pos": 14
         },
         "footer_rating_paragraph": {
           "type": "custom",
-          "pos": 11,
+          "pos": 15,
           "field_type": "markdown-html",
           "options": []
         },
         "footer_market_title": {
           "type": "text",
-          "pos": 12
+          "pos": 16
         },
         "footer_paragraph": {
           "type": "custom",
           "field_type": "markdown-html",
           "options": [],
-          "pos": 13,
+          "pos": 17,
           "translatable": true
         },
         "perils": {
@@ -659,28 +684,28 @@
           ],
           "restrict_components": true,
           "component_whitelist": ["peril_labels"],
-          "pos": 14
+          "pos": 18
         },
         "peril_modal_info_title": {
           "type": "text",
-          "pos": 15
+          "pos": 19
         },
         "peril_modal_coverage_title": {
           "type": "text",
-          "pos": 16
+          "pos": 20
         },
         "peril_modal_exceptions_title": {
           "type": "text",
-          "pos": 17
+          "pos": 21
         },
         "locale": {
           "type": "section",
           "keys": ["four_oh_four_title", "cookie_consent_message"],
-          "pos": 18
+          "pos": 22
         },
         "four_oh_four_title": {
           "type": "text",
-          "pos": 19
+          "pos": 23
         },
         "cookie_consent_message": {
           "type": "custom",
@@ -688,11 +713,11 @@
           "translatable": true,
           "field_type": "markdown-html",
           "options": [],
-          "pos": 20
+          "pos": 24
         },
         "structured_data": {
           "type": "section",
-          "pos": 21,
+          "pos": 25,
           "keys": [
             "structured_data_website_description",
             "structured_data_organization_description"
@@ -700,7 +725,7 @@
         },
         "structured_data_website_description": {
           "type": "text",
-          "pos": 22,
+          "pos": 26,
           "max_length": "",
           "description": "Description used in structured data \"WebSite\" type for rich search results.",
           "display_name": "WebSite Description",
@@ -708,13 +733,13 @@
         },
         "structured_data_organization_description": {
           "type": "text",
-          "pos": 23,
+          "pos": 27,
           "display_name": "Organization Description",
           "description": "Description used in structured data \"Organization\" type for rich search results."
         },
         "trustpilot": {
           "type": "section",
-          "pos": 24,
+          "pos": 28,
           "keys": [
             "structured_data_review_value",
             "structured_data_review_count"
@@ -722,12 +747,12 @@
         },
         "structured_data_review_value": {
           "type": "text",
-          "pos": 25,
+          "pos": 29,
           "description": "READ ONLY. This field is filled in automatically. Review score used in structured data \"AggregateRating\" type for rich search results."
         },
         "structured_data_review_count": {
           "type": "text",
-          "pos": 26,
+          "pos": 30,
           "description": "READ ONLY. This field is filled in automatically. Total number of reviews used in structured data \"AggregateRating\" type for rich search results."
         }
       },
@@ -838,6 +863,11 @@
         },
         "hide_menu": {
           "type": "boolean"
+        },
+        "hide_global_banner": {
+          "type": "boolean",
+          "display_name": "",
+          "description": "Hides the global top banner on this header block"
         }
       },
       "image": null,
@@ -2273,6 +2303,35 @@
       "all_presets": [],
       "preset_id": null,
       "real_name": "menu_item",
+      "component_group_uuid": null
+    },
+    {
+      "name": "menu_item_group",
+      "display_name": null,
+      "schema": {
+        "label": {
+          "type": "text",
+          "required": true,
+          "pos": 0,
+          "translatable": false
+        },
+        "menu_items": {
+          "type": "bloks",
+          "translatable": true,
+          "restrict_components": true,
+          "component_whitelist": ["menu_item"],
+          "display_name": "Group menu items",
+          "pos": 2
+        }
+      },
+      "image": null,
+      "preview_field": null,
+      "is_root": false,
+      "preview_tmpl": null,
+      "is_nestable": true,
+      "all_presets": [],
+      "preset_id": null,
+      "real_name": "menu_item_group",
       "component_group_uuid": null
     },
     {


### PR DESCRIPTION
## What & Why

Adds support for a global banner on the top of the site. This will allow to advertise new offerings or features

## Implementation

* The settings for the banner are setup in the Global block.
![Banner Top Global Settings](https://user-images.githubusercontent.com/89857278/132812332-f1474ef5-0c93-42c2-a366-75e43537faaa.png)
* One can override this setting and hide it per pages by toggling the checkbox in the Header Block config for that page
![Screenshot 2021-09-09 at 15 06 06](https://user-images.githubusercontent.com/89857278/132812532-16f7a653-f4f0-4128-8d7a-5c6e19e3ce89.png)
### Refactoring
* Started towards renaming HeaderBlockBrandPivot to HeaderBlock. Stopped short of renaming the folder of the block not to make the PR too confusing.

## Demo
<img width="1440" alt="Screenshot 2021-09-10 at 08 46 02" src="https://user-images.githubusercontent.com/89857278/132812648-9b18b08d-6d77-4dde-a382-2cc8e5ec77d9.png">
<img width="348" alt="Screenshot 2021-09-10 at 08 46 37" src="https://user-images.githubusercontent.com/89857278/132812656-6d7f7e13-223f-448b-8833-1cfbcf1d034f.png">

## Screen Recording
https://user-images.githubusercontent.com/89857278/132812726-372baee1-81f4-4d96-bbb6-1802f1ace0e1.mov


