### PR TITLE
Update perils query and add Accident as an option

### DIFF
--- a/src/components/Perils/data/useIcon.tsx
+++ b/src/components/Perils/data/useIcon.tsx
@@ -9,8 +9,7 @@ export const useIcon = (iconUrl: string) => {
       if (!iconUrl) {
         return
       }
-      const url = `https://giraffe.hedvig.com${iconUrl}`
-      const iconResponse = await axios.get(url, {
+      const iconResponse = await axios.get(iconUrl, {
         withCredentials: false,
       })
       seticonString(iconResponse.data)

--- a/src/components/Perils/data/usePerils.ts
+++ b/src/components/Perils/data/usePerils.ts
@@ -32,7 +32,7 @@ export const usePerils = (insuranceType: TypeOfContract, localeIso: Locale) => {
         },
         query: `
           query Perils($typeOfContract: TypeOfContract!, $localeIso: Locale!) {
-            perils(contractType: $typeOfContract, locale: $localeIso) {
+            contractPerils(contractType: $typeOfContract, locale: $localeIso) {
                 title
                 description
                 covered
@@ -55,7 +55,7 @@ export const usePerils = (insuranceType: TypeOfContract, localeIso: Locale) => {
           'content-type': 'application/json',
         },
       })
-      const perilsData = perilsRequest.data.data.perils
+      const perilsData = perilsRequest.data.data.contractPerils
       setPerils(perilsData)
     }
 

--- a/storyblok/components.json
+++ b/storyblok/components.json
@@ -2193,6 +2193,10 @@
               "name": "SE_APARTMENT_STUDENT_RENT"
             },
             {
+              "value": "SE_ACCIDENT",
+              "name": "SE_ACCIDENT"
+            },
+            {
               "value": "NO_HOME_CONTENT_OWN",
               "name": "NO_HOME_CONTENT_OWN"
             },


### PR DESCRIPTION
## What?

- Update query from `perils` to `contractPerils`. The new url is absolute and will go to a bucket on S3.
- Add Accident contract types to Perils block

@joacimastrom is updating the CORS permissions for icons, since they were initially blocked. 

## Why?
Perils are no longer fetched from content-service but should be fetched from the new Promise CMS

We're currently live with these pages so would be good to get out asap :) 

<img width="899" alt="Screenshot 2021-10-07 at 16 04 06" src="https://user-images.githubusercontent.com/6661511/136402794-fafd2821-219b-499a-b124-616012e32de3.png">


