### PR TITLE
Update PR template to be the same as in web-onboarding repo

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,15 @@
+<!-- 
+To link the branch/PR to a Jira issue either
+1. (preferred) add the issue key to the name of your branch (e.g. GRW-123/fix/some-annoying-bug)
+2. prefix your PR title with it
+
+Also, if applicable, include whether this is a Fix, Feature or Chore.
+Example PR title: GRW-123 / Feature / Awesome new thing
+-->
+
 ## What?
 
-<!-- What changes are made? If there are many significant changes, a list might be a good format. -->
+<!-- What changes are made? If there are many changes, a list might be a good format. -->
 
 
 ## Why?
@@ -8,8 +17,17 @@
 <!-- Why are these changes made? -->
 
 
-<!-- If there is one, add the Jira issue ID in brackets below. This will create a link to that issue. -->
-_Referenced ticket: []_
+<!-- If there is a Jira issue, add the key (e.g. GRW-123) between brackets below, and a link to that issue will automaticaly be created. -->
+**Referenced ticket(s): []**
 
 
-<!-- And, if that makes sense, add screenshots and/or GIF's below -->
+
+<!-- If it makes sense, add screenshots and/or screen recordings below, preferably with headlines and/or descriptions -->
+<!--
+## Screenshots / recordings 
+-->
+
+<!-- Finally, you can create a review app on Heroku if you think that will be helpful to the reviewers -->
+<!--
+## Review app
+-->


### PR DESCRIPTION
## What?

<!-- What changes are made? If there are many significant changes, a list might be a good format. -->
- Update the PR template to look the same as the [proposed updated one in `web-onboarding`](https://github.com/HedvigInsurance/web-onboarding/pull/680)


## Why?

<!-- Why are these changes made? -->
- Same reasons as in PR linked above
- I think we should use the same template for all our repos


<!-- If there is one, add the Jira issue ID in brackets below. This will create a link to that issue. -->



<!-- And, if that makes sense, add screenshots and/or GIF's below -->
