### PR TITLE
Add duplicated block to enable renaming and migration

### DIFF
--- a/src/blocks/BulletPointBlock.tsx
+++ b/src/blocks/BulletPointBlock.tsx
@@ -1,0 +1,187 @@
+import styled from '@emotion/styled'
+import React from 'react'
+import {
+  ContentWrapper,
+  getMinimalColorStyles,
+  LAPTOP_BP_UP,
+  MOBILE_BP_DOWN,
+  MOBILE_BP_UP,
+  SectionWrapper,
+  TABLET_BP_UP,
+} from 'components/blockHelpers'
+import { DeferredImage } from 'components/DeferredImage'
+import { getStoryblokImage, Image } from 'utils/storyblok'
+import {
+  BaseBlockProps,
+  MarkdownHtmlComponent,
+  MinimalColorComponent,
+} from 'blocks/BaseBlockProps'
+
+const BulletPointSectionWrapper = styled(SectionWrapper)({
+  overflowX: 'hidden',
+})
+
+const InnerWrapper = styled('div')({
+  display: 'flex',
+  flexWrap: 'wrap',
+  minWidth: '100%',
+
+  [MOBILE_BP_DOWN]: {
+    paddingLeft: '8px',
+    paddingRight: '8px',
+  },
+
+  [MOBILE_BP_UP]: {
+    marginLeft: '-1.5rem',
+  },
+
+  [LAPTOP_BP_UP]: {
+    marginLeft: '-3.5rem',
+  },
+})
+
+const BulletPoint = styled('div')<{
+  alignCenter: boolean
+}>(({ alignCenter }) => ({
+  display: 'flex',
+  flexDirection: alignCenter ? 'column' : 'row',
+  alignItems: alignCenter ? 'center' : 'flex-start',
+  textAlign: alignCenter ? 'center' : 'left',
+  width: '100%',
+  marginTop: '1.25rem',
+  marginBottom: '1.25rem',
+
+  [MOBILE_BP_UP]: {
+    flexDirection: 'column',
+    width: `calc(50% - 1.5rem)`,
+    marginLeft: '1.5rem',
+  },
+
+  [TABLET_BP_UP]: {
+    width: `calc(${(1 / 3) * 100}% - 1.5rem)`,
+  },
+
+  [LAPTOP_BP_UP]: {
+    width: `calc(${(1 / 3) * 100}% - 3.5rem)`,
+    marginLeft: '3.5rem',
+  },
+}))
+
+const BulletPointHead = styled('div')<{
+  alignCenter: boolean
+}>(({ alignCenter }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  flexShrink: 0,
+  marginBottom: '1.5rem',
+
+  ...(alignCenter
+    ? {
+        marginBottom: '1.5rem',
+      }
+    : {
+        justifyContent: 'flex-start',
+        maxWidth: '2rem',
+        maxHeight: '2rem',
+        marginRight: '1.5rem',
+
+        [MOBILE_BP_UP]: {
+          maxWidth: 'none',
+          maxHeight: 'none',
+          width: 'auto',
+          marginRight: 0,
+          marginBottom: alignCenter ? '2rem' : '1.25rem',
+        },
+      }),
+}))
+
+const BulletPointImage = styled(DeferredImage)<{
+  alignCenter: boolean
+}>(({ alignCenter }) => ({
+  width: alignCenter ? 'auto' : '100%',
+}))
+
+const BulletPointTitle = styled('h3')({
+  marginTop: 0,
+  fontSize: '1.5rem',
+
+  [LAPTOP_BP_UP]: {
+    fontSize: '2rem',
+    marginBottom: '2rem',
+  },
+})
+
+const BulletPointBody = styled('div')<{
+  alignCenter: boolean
+  colorComponent: MinimalColorComponent
+}>(({ alignCenter, colorComponent }) => ({
+  maxWidth: alignCenter ? '16rem' : 'none',
+  color: getMinimalColorStyles(colorComponent?.color ?? 'standard').color,
+  fontSize: alignCenter ? '18px' : '16px',
+
+  ['p']: {
+    marginTop: '0',
+  },
+
+  [LAPTOP_BP_UP]: {
+    fontSize: '1.125rem',
+  },
+}))
+
+interface BulletPointsBlockProps extends BaseBlockProps {
+  align_center: boolean
+  color_body: MinimalColorComponent
+  bullet_points: ReadonlyArray<
+    BaseBlockProps & {
+      image: Image
+      icon_layout: boolean
+      title?: string
+      paragraph: MarkdownHtmlComponent
+    }
+  >
+}
+
+export const BulletPointBlock: React.FC<BulletPointsBlockProps> = ({
+  align_center,
+  extra_styling,
+  color,
+  color_body,
+  size,
+  bullet_points,
+}) => (
+  <BulletPointSectionWrapper
+    brandPivot
+    colorComponent={color}
+    size={size}
+    extraStyling={extra_styling}
+  >
+    <ContentWrapper brandPivot>
+      <InnerWrapper>
+        {bullet_points.map((bullet) => (
+          <BulletPoint key={bullet._uid} alignCenter={align_center}>
+            {bullet.image && (
+              <BulletPointHead alignCenter={align_center}>
+                <BulletPointImage
+                  src={getStoryblokImage(bullet.image)}
+                  alignCenter={align_center}
+                />
+              </BulletPointHead>
+            )}
+            <div>
+              {bullet.title && (
+                <BulletPointTitle>{bullet.title}</BulletPointTitle>
+              )}
+              <BulletPointBody
+                alignCenter={align_center}
+                colorComponent={color_body}
+                dangerouslySetInnerHTML={{
+                  __html: bullet.paragraph?.html,
+                }}
+              />
+            </div>
+          </BulletPoint>
+        ))}
+      </InnerWrapper>
+    </ContentWrapper>
+  </BulletPointSectionWrapper>
+)

--- a/src/blocks/index.tsx
+++ b/src/blocks/index.tsx
@@ -9,6 +9,7 @@ import { AppButtonsBlock } from './AppButtonsBlock'
 import { BackgroundVideoBlock } from './BackgroundVideoBlock'
 import { BannerBlock } from './BannerBlock/BannerBlock'
 import { BaseBlockProps } from './BaseBlockProps'
+import { BulletPointBlock } from './BulletPointBlock'
 import { BulletPointBlockBrandPivot } from './BulletPointBlockBrandPivot'
 import { CtaBlock } from './CtaBlock/CtaBlock'
 import { HeaderBlock } from './HeaderBlockBrandPivot'
@@ -29,6 +30,7 @@ const blockComponents = {
   accordion_block: AccordionBlock,
   accordion_block_brand_pivot: AccordionBlock,
   banner_block: BannerBlock,
+  bullet_point_block: BulletPointBlock,
   bullet_point_block_brand_pivot: BulletPointBlockBrandPivot,
   column_text_block: ColumnTextBlock,
   cta_block: CtaBlock,


### PR DESCRIPTION
## What?
Add duplicate of `BulletPointBlockBrandPivot` without BrandPivot suffix. We need to keep the old one in the transition between component usage. Tis enable us to rename the component from `bullet_point_block_brand_pivot` to `bullet_point_block` without the need to migrate content.


## Why?
To remove BrandPivot suffix of the component. In order to do that we need to rename the component in the the space component dashboard. Storyblok will automatically migrate to the new name (see screenshot). We can't update `components.json` before the migration of content is done in the actual space. Works fine locally and will double check in staging. When doing this in prod I will also lock the editing capabilities for ediotors.

<img width="449" alt="Screenshot 2021-12-14 at 14 48 04" src="https://user-images.githubusercontent.com/6661511/146015911-3fd63a8f-cfc3-4e34-bce3-128cf059cea0.png">

Didn't know this had been a feature for a long time :) https://www.storyblok.com/cl/component-renamer

