### PR TITLE
Set default font-size for Bullet Point Item Title

### DIFF
--- a/src/blocks/BulletPointBlock/BulletPointBlock.tsx
+++ b/src/blocks/BulletPointBlock/BulletPointBlock.tsx
@@ -167,7 +167,7 @@ export const BulletPointBlock = ({
     size={size}
     extraStyling={extra_styling}
   >
-    <ContentWrapper fullWidth>
+    <ContentWrapper brandPivot>
       <InnerWrapper>
         {bullet_points.map((bullet) => (
           <BulletPoint
@@ -189,7 +189,7 @@ export const BulletPointBlock = ({
                 <BulletPointTitle
                   as="h3"
                   size={bullet.title_size}
-                  mobileSize={bullet.title_size_mobile}
+                  mobileSize={bullet.title_size_mobile || 'sm'}
                 >
                   {bullet.title}
                 </BulletPointTitle>


### PR DESCRIPTION
## What?

- Set default font-size for Bullet Point Item Title
- Revert to previous container width


## Why?
This saves us the time from having to manually update all use cases of this block in prod. Since most times it should have size `md`

