### PR TITLE
Rename BrandPivot image blocks

### DIFF
--- a/src/blocks/AccordionBlock/AccordionBlock.tsx
+++ b/src/blocks/AccordionBlock/AccordionBlock.tsx
@@ -3,10 +3,7 @@ import { Container } from 'constate'
 import React from 'react'
 import AnimateHeight from 'react-animate-height'
 import Helmet from 'react-helmet-async'
-import {
-  BrandPivotBaseBlockProps,
-  MarkdownHtmlComponent,
-} from 'blocks/BaseBlockProps'
+import { BaseBlockProps, MarkdownHtmlComponent } from 'blocks/BaseBlockProps'
 import {
   ContentWrapper,
   SectionWrapper,
@@ -166,7 +163,7 @@ export const Accordion: React.FC<AccordionProps> = ({ title, paragraph }) => (
   </Container>
 )
 
-export interface AccordionBlockProps extends BrandPivotBaseBlockProps {
+export interface AccordionBlockProps extends BaseBlockProps {
   title: string
   accordions: ReadonlyArray<AccordionProps>
   is_faq?: boolean

--- a/src/blocks/AppButtonsBlock.tsx
+++ b/src/blocks/AppButtonsBlock.tsx
@@ -1,10 +1,7 @@
 import React from 'react'
 import { AppButtons } from 'components/AppButtons/AppButtons'
 import { ContentWrapper, SectionWrapper } from 'components/blockHelpers'
-import {
-  BrandPivotBaseBlockProps,
-  minimalColorComponentColors,
-} from './BaseBlockProps'
+import { BaseBlockProps, minimalColorComponentColors } from './BaseBlockProps'
 
 type StandardColor = 'standard' | 'standard-inverse'
 
@@ -17,7 +14,7 @@ const isStandardColor = (
   color: minimalColorComponentColors,
 ): color is StandardColor => STANDARD_COLORS.includes(color)
 
-export const AppButtonsBlock: React.FC<BrandPivotBaseBlockProps> = ({
+export const AppButtonsBlock: React.FC<BaseBlockProps> = ({
   index,
   color,
   extra_styling,

--- a/src/blocks/BackgroundVideoBlock.tsx
+++ b/src/blocks/BackgroundVideoBlock.tsx
@@ -17,7 +17,7 @@ import {
 import { LinkComponent } from '../storyblok/StoryContainer'
 import { getStoryblokLinkUrl } from '../utils/storyblok'
 import {
-  BaseBlockProps,
+  BaseBlockPropsDeprecated,
   ColorComponent,
   MarkdownHtmlComponent,
 } from './BaseBlockProps'
@@ -126,7 +126,7 @@ const GhostCta = styled(Cta)({
   },
 })
 
-interface BackgroundVideoBlockProps extends BaseBlockProps {
+interface BackgroundVideoBlockProps extends BaseBlockPropsDeprecated {
   video_file_location: string
   use_text_drop_shadow: boolean
   background_gradient_start: string

--- a/src/blocks/BannerBlock/BannerBlock.tsx
+++ b/src/blocks/BannerBlock/BannerBlock.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import React from 'react'
 import {
-  BaseBlockProps,
+  BaseBlockPropsDeprecated,
   MarkdownHtmlComponent,
 } from 'src/blocks/BaseBlockProps'
 import {
@@ -27,7 +27,7 @@ const BannerContent = styled('div')({
   },
 })
 
-interface BannerBlockProps extends BaseBlockProps {
+interface BannerBlockProps extends BaseBlockPropsDeprecated {
   text: MarkdownHtmlComponent
 }
 

--- a/src/blocks/BaseBlockProps.ts
+++ b/src/blocks/BaseBlockProps.ts
@@ -72,11 +72,11 @@ export interface BrandAgnosticBaseBlockProps {
   index?: number
 }
 
-export interface BaseBlockProps extends BrandAgnosticBaseBlockProps {
+export interface BaseBlockPropsDeprecated extends BrandAgnosticBaseBlockProps {
   color?: ColorComponent
 }
 
-export interface BrandPivotBaseBlockProps extends BrandAgnosticBaseBlockProps {
+export interface BaseBlockProps extends BrandAgnosticBaseBlockProps {
   color?: MinimalColorComponent
 }
 

--- a/src/blocks/BulletPointBlock/BulletPointBlock.tsx
+++ b/src/blocks/BulletPointBlock/BulletPointBlock.tsx
@@ -12,7 +12,7 @@ import {
 import { DeferredImage } from 'components/DeferredImage'
 import { getStoryblokImage, Image } from 'utils/storyblok'
 import {
-  BrandPivotBaseBlockProps,
+  BaseBlockProps,
   MarkdownHtmlComponent,
   MinimalColorComponent,
 } from 'blocks/BaseBlockProps'
@@ -136,7 +136,7 @@ const BulletPointBody = styled.div<{
 `
 
 export type BulletPointItemProps = ReadonlyArray<
-  BrandPivotBaseBlockProps & {
+  BaseBlockProps & {
     image: Image
     title?: string
     title_size: FontSizes
@@ -145,7 +145,7 @@ export type BulletPointItemProps = ReadonlyArray<
   }
 >
 
-export type BulletPointBlockProps = BrandPivotBaseBlockProps & {
+export type BulletPointBlockProps = BaseBlockProps & {
   align_center: boolean
   bullet_point_layout: boolean
   color_body: MinimalColorComponent

--- a/src/blocks/ColumnTextBlock/ColumnTextBlock.tsx
+++ b/src/blocks/ColumnTextBlock/ColumnTextBlock.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import React from 'react'
 import {
-  BaseBlockProps,
+  BaseBlockPropsDeprecated,
   MarkdownHtmlComponent,
 } from 'src/blocks/BaseBlockProps'
 import {
@@ -35,7 +35,7 @@ const Column = styled('div')({
   },
 })
 
-interface ColumnTextBlockProps extends BaseBlockProps {
+interface ColumnTextBlockProps extends BaseBlockPropsDeprecated {
   text_one: MarkdownHtmlComponent
   text_two: MarkdownHtmlComponent
 }

--- a/src/blocks/CtaBlock/CtaBlock.tsx
+++ b/src/blocks/CtaBlock/CtaBlock.tsx
@@ -7,12 +7,9 @@ import {
 } from 'components/ButtonBrandPivot/Button'
 import { LinkComponent } from 'src/storyblok/StoryContainer'
 import { getStoryblokLinkUrl } from 'utils/storyblok'
-import {
-  BrandPivotBaseBlockProps,
-  MinimalColorComponent,
-} from '../BaseBlockProps'
+import { BaseBlockProps, MinimalColorComponent } from '../BaseBlockProps'
 
-export interface CtaBlockProps extends BrandPivotBaseBlockProps {
+export interface CtaBlockProps extends BaseBlockProps {
   cta_label: string
   cta_link: LinkComponent
   cta_color?: MinimalColorComponent

--- a/src/blocks/FooterBlock/FooterBlock.tsx
+++ b/src/blocks/FooterBlock/FooterBlock.tsx
@@ -13,7 +13,7 @@ import {
 import { StarRating } from 'components/icons/StarRating'
 import { GlobalStory, GlobalStoryContainer } from 'storyblok/StoryContainer'
 import { getStoryblokLinkUrl } from 'utils/storyblok'
-import { BrandPivotBaseBlockProps } from '../BaseBlockProps'
+import { BaseBlockProps } from '../BaseBlockProps'
 import { MarketPicker } from './MarketPicker/MarketPicker'
 
 const BP_UP = '@media (min-width: 601px)'
@@ -184,7 +184,7 @@ const FooterFooter = styled(DoubleColumn)`
   }
 `
 
-type FooterBlockProps = BrandPivotBaseBlockProps
+type FooterBlockProps = BaseBlockProps
 
 export const Footer: React.FC<{ story: GlobalStory } & FooterBlockProps> = ({
   color,

--- a/src/blocks/HeaderBlockBrandPivot/index.tsx
+++ b/src/blocks/HeaderBlockBrandPivot/index.tsx
@@ -15,7 +15,7 @@ import {
 } from '../../storyblok/StoryContainer'
 import { getStoryblokLinkUrl } from '../../utils/storyblok'
 import {
-  BaseBlockProps,
+  BaseBlockPropsDeprecated,
   MinimalColorComponent,
   minimalColorComponentColors,
 } from '../BaseBlockProps'
@@ -213,7 +213,7 @@ const Wordmark = styled('a')({
   zIndex: 102,
 })
 
-interface HeaderBlockProps extends BaseBlockProps {
+interface HeaderBlockProps extends BaseBlockPropsDeprecated {
   is_transparent: boolean
   inverse_colors: boolean
   override_cta_link?: LinkComponent | null

--- a/src/blocks/HeadlineBlock/HeadlineBlock.tsx
+++ b/src/blocks/HeadlineBlock/HeadlineBlock.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import React from 'react'
 import { HedvigSymbol } from '@hedviginsurance/brand'
-import { BrandPivotBaseBlockProps } from 'blocks/BaseBlockProps'
+import { BaseBlockProps } from 'blocks/BaseBlockProps'
 import {
   ContentWrapper,
   SectionWrapper,
@@ -10,7 +10,7 @@ import {
 import { FontSizes, Heading } from 'components/Heading/Heading'
 import { TextPosition } from 'utils/textPosition'
 
-interface HeadlineBlockProps extends BrandPivotBaseBlockProps {
+interface HeadlineBlockProps extends BaseBlockProps {
   text: string
   text_position: TextPosition
   capitalize?: boolean

--- a/src/blocks/HeroBlock/HeroBlock.tsx
+++ b/src/blocks/HeroBlock/HeroBlock.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled'
 import React from 'react'
 import { HedvigSymbol } from '@hedviginsurance/brand'
 import {
-  BrandPivotBaseBlockProps,
+  BaseBlockProps,
   MarkdownHtmlComponent,
   MinimalColorComponent,
 } from 'blocks/BaseBlockProps'
@@ -161,7 +161,7 @@ const ButtonWrapper = styled.div<Animatable>`
   }
 `
 
-export interface HeroBlockProps extends BrandPivotBaseBlockProps {
+export interface HeroBlockProps extends BaseBlockProps {
   headline: string
   headline_font_size: FontSizes
   headline_font_size_mobile?: FontSizes

--- a/src/blocks/HeroImageBlockBrandPivot/HeroImageBlockBrandPivot.tsx
+++ b/src/blocks/HeroImageBlockBrandPivot/HeroImageBlockBrandPivot.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled'
 import React from 'react'
 import { HedvigSymbol } from '@hedviginsurance/brand'
 import {
-  BrandPivotBaseBlockProps,
+  BaseBlockProps,
   MarkdownHtmlComponent,
   MinimalColorComponent,
 } from 'blocks/BaseBlockProps'
@@ -126,8 +126,7 @@ const ButtonWrapper = styled('div')({
   },
 })
 
-export interface HeroImageBlockBrandPivotProps
-  extends BrandPivotBaseBlockProps {
+export interface HeroImageBlockBrandPivotProps extends BaseBlockProps {
   headline: string
   headline_font_size: FontSizes
   headline_font_size_mobile?: FontSizes

--- a/src/blocks/ImageBlock/ImageBlock.stories.tsx
+++ b/src/blocks/ImageBlock/ImageBlock.stories.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { Image as ImageType } from '../../utils/storyblok'
+import { MarkdownHtmlComponent } from '../BaseBlockProps'
+import { ImageBlock } from './ImageBlock'
+
+const image: ImageType =
+  'https://cdn.hedvig.com/www/referrals/referrals-clean.png'
+
+export default {
+  title: 'Blocks/ImageBlock',
+  component: ImageBlock,
+  parameters: {
+    paddings: [
+      { name: 'Medium', value: '32px' },
+      { name: 'Large', value: '64px', default: true },
+    ],
+  },
+}
+
+const caption: MarkdownHtmlComponent = {
+  _uid: '5',
+  html: '<p>Bildtext</p><p>Stockholm, 2020</p>',
+  original: '<p>Bildtext</p><p>Stockholm, 2020</p>',
+  plugin: 'markdown-html',
+}
+
+export const Default = () => (
+  <ImageBlock _uid="5678" component="image_block" image={image} />
+)
+
+export const WithCaption = () => (
+  <ImageBlock
+    _uid="5678"
+    component="image_block"
+    image={image}
+    caption={caption}
+  />
+)

--- a/src/blocks/ImageBlock/ImageBlock.tsx
+++ b/src/blocks/ImageBlock/ImageBlock.tsx
@@ -1,0 +1,46 @@
+import styled from '@emotion/styled'
+import React from 'react'
+import { Caption } from 'components/Caption'
+import { ContentWrapper } from '../../components/blockHelpers'
+import { DeferredImage } from '../../components/DeferredImage'
+import { getStoryblokImage, Image as ImageType } from '../../utils/storyblok'
+import { BaseBlockProps, MarkdownHtmlComponent } from '../BaseBlockProps'
+
+interface ImageBlockProps extends BaseBlockProps {
+  image: ImageType
+  caption?: MarkdownHtmlComponent
+  full_width?: boolean
+}
+
+const StyledContentWrapper = styled(ContentWrapper)<{ extraStyling?: string }>`
+  ${({ extraStyling }) => String(extraStyling)}
+`
+
+const ImageWrapper = styled.div`
+  position: relative;
+`
+
+const Image = styled(DeferredImage)({
+  display: 'block',
+  width: '100%',
+})
+
+export const ImageBlock: React.FunctionComponent<ImageBlockProps> = ({
+  image,
+  caption,
+  full_width = false,
+  index,
+  extra_styling,
+}) => (
+  <StyledContentWrapper
+    brandPivot
+    fullWidth={full_width}
+    index={index}
+    extraStyling={extra_styling}
+  >
+    <ImageWrapper>
+      <Image src={getStoryblokImage(image)} />
+      {caption && <Caption caption={caption} />}
+    </ImageWrapper>
+  </StyledContentWrapper>
+)

--- a/src/blocks/ImageBlockBrandPivot/ImageBlockBrandPivot.tsx
+++ b/src/blocks/ImageBlockBrandPivot/ImageBlockBrandPivot.tsx
@@ -4,12 +4,9 @@ import { Caption } from 'components/Caption'
 import { ContentWrapper } from '../../components/blockHelpers'
 import { DeferredImage } from '../../components/DeferredImage'
 import { getStoryblokImage, Image as ImageType } from '../../utils/storyblok'
-import {
-  BrandPivotBaseBlockProps,
-  MarkdownHtmlComponent,
-} from '../BaseBlockProps'
+import { BaseBlockProps, MarkdownHtmlComponent } from '../BaseBlockProps'
 
-interface ImageBlockProps extends BrandPivotBaseBlockProps {
+interface ImageBlockProps extends BaseBlockProps {
   image: ImageType
   caption?: MarkdownHtmlComponent
   full_width?: boolean

--- a/src/blocks/ImageTextBlock/BackgroundVideo.tsx
+++ b/src/blocks/ImageTextBlock/BackgroundVideo.tsx
@@ -1,0 +1,90 @@
+import { keyframes } from '@emotion/core'
+import styled from '@emotion/styled'
+import React from 'react'
+import MediaQuery from 'react-responsive'
+import { backgroundImageStyles } from '../../components/blockHelpers'
+import { DeferredVideo } from '../../components/DeferredVideo'
+
+interface BackgroundProps {
+  backgroundColor: string
+}
+
+const fadeInKeyframe = keyframes({
+  from: {
+    opacity: 0,
+  },
+  to: {
+    opacity: 1,
+  },
+})
+
+const HeightContainer = styled('div')<BackgroundProps>(
+  ({ backgroundColor }) => ({
+    animation: `${fadeInKeyframe} 2000ms forwards`,
+    transition: 'height 1500ms, padding 1500ms',
+    overflow: 'hidden',
+    display: 'flex',
+    alignItems: 'center',
+    backgroundColor,
+    position: 'absolute',
+    top: 0,
+    width: '100%',
+    height: '100%',
+  }),
+)
+
+const BackgroundImage = styled('div')<{ image: string }>(({ image }) => ({
+  height: '100%',
+  overflow: 'hidden',
+  width: '100%',
+  ...backgroundImageStyles(image),
+}))
+
+const VideoWrapper = styled('div')({
+  height: '100%',
+  overflow: 'hidden',
+  width: '100%',
+  position: 'relative',
+})
+
+interface PlayerProps {
+  baseMobileVideoUrl: string
+  baseVideoUrl: string
+  desktopImage: string
+  mobileImage: string
+}
+
+interface VideoItemProps {
+  videoUrl: string
+}
+
+const VideoItem: React.FunctionComponent<VideoItemProps> = ({ videoUrl }) => (
+  <VideoWrapper>
+    <DeferredVideo src={videoUrl} />
+  </VideoWrapper>
+)
+
+export const BackgroundVideo: React.SFC<PlayerProps & BackgroundProps> = ({
+  desktopImage,
+  mobileImage,
+  baseVideoUrl,
+  baseMobileVideoUrl,
+  backgroundColor,
+}) => (
+  <HeightContainer backgroundColor={backgroundColor}>
+    <MediaQuery query="(max-width: 700px)">
+      {baseMobileVideoUrl ? (
+        <VideoItem videoUrl={baseMobileVideoUrl} />
+      ) : (
+        mobileImage && <BackgroundImage image={mobileImage} />
+      )}
+    </MediaQuery>
+    <MediaQuery query="(min-width: 701px)">
+      {baseVideoUrl ? (
+        <VideoItem videoUrl={baseVideoUrl} />
+      ) : (
+        desktopImage && <BackgroundImage image={desktopImage} />
+      )}
+    </MediaQuery>
+  </HeightContainer>
+)

--- a/src/blocks/ImageTextBlock/index.tsx
+++ b/src/blocks/ImageTextBlock/index.tsx
@@ -27,7 +27,7 @@ import {
   Image as StoryblokImage,
 } from '../../utils/storyblok'
 import {
-  BrandPivotBaseBlockProps,
+  BaseBlockProps,
   MarkdownHtmlComponent,
   MinimalColorComponent,
 } from '../BaseBlockProps'
@@ -220,7 +220,7 @@ const Wordmark = styled('div')({
   },
 })
 
-interface ImageTextBlockProps extends BrandPivotBaseBlockProps {
+interface ImageTextBlockProps extends BaseBlockProps {
   animate?: boolean
   title_size?: FontSizes
   title_size_mobile?: FontSizes

--- a/src/blocks/ImageTextBlock/index.tsx
+++ b/src/blocks/ImageTextBlock/index.tsx
@@ -1,0 +1,441 @@
+import { keyframes } from '@emotion/core'
+import styled from '@emotion/styled'
+import React, { useEffect, useState } from 'react'
+import MediaQuery from 'react-responsive'
+import { HedvigSymbol } from '@hedviginsurance/brand'
+import { FontSizes, Heading } from 'components/Heading/Heading'
+import { LinkComponent } from 'src/storyblok/StoryContainer'
+import { SectionSize } from 'src/utils/SectionSize'
+import { TextPosition } from 'src/utils/textPosition'
+import {
+  AlignedButton,
+  AlignedButtonProps,
+} from '../../components/AlignedButton'
+import {
+  ContentWrapper,
+  getMinimalColorStyles,
+  MOBILE_BP_DOWN,
+  MOBILE_BP_UP,
+  SectionWrapper,
+  TABLET_BP_DOWN,
+  TABLET_BP_UP,
+} from '../../components/blockHelpers'
+import { DeferredImage } from '../../components/DeferredImage'
+import { DeferredVideo } from '../../components/DeferredVideo'
+import {
+  getStoryblokImage,
+  Image as StoryblokImage,
+} from '../../utils/storyblok'
+import {
+  BrandPivotBaseBlockProps,
+  MarkdownHtmlComponent,
+  MinimalColorComponent,
+} from '../BaseBlockProps'
+import { BackgroundVideo } from './BackgroundVideo'
+
+interface Animateable {
+  animate?: boolean
+}
+
+const AlignableContentWrapper = styled(ContentWrapper)<{
+  textPosition: TextPosition
+}>(({ textPosition }) => ({
+  padding: '0 1rem',
+  display: 'flex',
+  position: 'relative',
+  flexDirection:
+    textPosition === 'right'
+      ? 'row-reverse'
+      : textPosition === 'center'
+      ? 'column'
+      : 'row',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  [MOBILE_BP_DOWN]: {
+    flexDirection: 'column',
+  },
+}))
+
+const fadeSlideIn = keyframes({
+  from: { opacity: 0, transform: 'translateY(15%)' },
+  to: { opacity: 1, transform: 'translateY(0)' },
+})
+const AnimatedAlignedButton = styled(AlignedButton)<
+  Animateable & AlignedButtonProps<MinimalColorComponent>
+>(({ animate }) => ({
+  opacity: animate ? 0 : 1,
+  animation: animate ? fadeSlideIn + ' 1000ms ease-out forwards' : undefined,
+  animationDelay: '1000ms',
+  width: '100%',
+  [MOBILE_BP_UP]: {
+    maxWidth: 'auto',
+  },
+}))
+
+const TextWrapper = styled('div')<{
+  textPosition: TextPosition
+  textPositionMobile: TextPosition
+  isBlockFullWidth: boolean
+}>(({ textPosition, textPositionMobile, isBlockFullWidth }) => ({
+  position: 'relative',
+  textAlign: textPosition === 'center' ? 'center' : 'left',
+  width: '100%',
+  ...(textPosition === 'left' && {
+    paddingLeft: isBlockFullWidth ? '4rem' : 0,
+    paddingRight: '4rem',
+  }),
+  ...(textPosition === 'right' && {
+    paddingLeft: '4rem',
+    paddingRight: isBlockFullWidth ? '4rem' : 0,
+  }),
+  [TABLET_BP_DOWN]: {
+    paddingRight: textPosition === 'left' ? '3rem' : '0',
+    paddingLeft: textPosition === 'right' ? '3rem' : '0',
+  },
+  [MOBILE_BP_DOWN]: {
+    paddingRight: 0,
+    paddingLeft: 0,
+    textAlign: textPositionMobile,
+  },
+}))
+
+type DisplayOrder = 'top' | 'bottom'
+
+interface TitleProps {
+  displayorder: DisplayOrder
+  alignment: TextPosition
+}
+
+const Title = styled(Heading)<TitleProps & Animateable>(
+  ({ displayorder, alignment, animate }) => ({
+    width: '100%',
+    maxWidth: alignment === 'center' ? '40rem' : 'none',
+    margin: alignment === 'center' ? 'auto' : undefined,
+    marginTop: displayorder === 'top' ? '3rem' : '1.414rem',
+    opacity: animate ? 0 : 1,
+    animation: animate ? fadeSlideIn + ' 500ms forwards' : undefined,
+    animationDelay: '1000ms',
+
+    ['br']: {
+      display: 'none',
+    },
+
+    [TABLET_BP_UP]: {
+      marginTop:
+        alignment === 'center' && displayorder === 'top' ? '3rem' : '1.414rem',
+      ['br']: {
+        display: 'block',
+      },
+    },
+  }),
+)
+
+const Paragraph = styled('div')<
+  {
+    textPosition: TextPosition
+    colorComponent?: MinimalColorComponent
+  } & Animateable
+>(({ textPosition, colorComponent, animate }) => ({
+  margin: textPosition === 'center' ? 'auto' : undefined,
+  fontSize: '1.125rem',
+  marginTop: '1.5rem',
+  maxWidth: textPosition === 'center' ? '40rem' : '31rem',
+  opacity: animate ? 0 : 1,
+  animation: animate ? fadeSlideIn + ' 500ms forwards' : undefined,
+  animationDelay: '1250ms',
+  color: getMinimalColorStyles(colorComponent?.color ?? 'standard')
+    .secondaryColor,
+
+  [TABLET_BP_DOWN]: {
+    maxWidth: '100%',
+    ['br']: {
+      display: 'none',
+    },
+  },
+}))
+
+const Image = styled(DeferredImage)<{
+  alignment: string
+  displayorder: DisplayOrder
+  smallImage: boolean
+}>(({ alignment, displayorder, smallImage }) => ({
+  width: `calc(${smallImage ? '(100% / 3)' : '50%'} - 0.75rem)`,
+  display: 'block',
+  flexShrink: 0,
+  order: alignment === 'center' && displayorder === 'top' ? -1 : 'initial',
+  overflow: 'hidden',
+  [MOBILE_BP_DOWN]: {
+    maxWidth: '100%',
+    width: 'auto',
+    marginTop: displayorder === 'top' ? '0' : '3rem',
+    display: 'block',
+    order: displayorder === 'top' ? -1 : 'initial',
+  },
+}))
+
+const ImageVideoWrapper = styled('div')<{
+  alignment: string
+  displayorder: DisplayOrder
+  smallImage: boolean
+}>(({ alignment, displayorder, smallImage }) => ({
+  width: `calc(${smallImage ? '(100% / 3)' : '50%'} - 0.75rem)`,
+  flexShrink: 0,
+  display: 'block',
+  order: alignment === 'center' && displayorder === 'top' ? -1 : 'initial',
+  overflow: 'hidden',
+  [MOBILE_BP_DOWN]: {
+    maxWidth: '100%',
+    width: 'auto',
+    marginTop: displayorder === 'top' ? '0' : '3rem',
+    display: 'block',
+    order: displayorder === 'top' ? -1 : 'initial',
+  },
+}))
+
+const ImageVideo = styled(DeferredVideo)({
+  width: '100%',
+  objectFit: 'cover',
+  transition: 'height 1500ms',
+  overflow: 'hidden',
+})
+
+const Wordmark = styled('div')({
+  display: 'inline-flex',
+  position: 'absolute',
+  marginTop: '0.33em',
+  marginLeft: '0.2rem',
+
+  ['svg']: {
+    width: '0.625rem',
+    height: '0.625rem',
+  },
+
+  [TABLET_BP_UP]: {
+    marginTop: '0.25em',
+    marginLeft: '0.5rem',
+    ['svg']: {
+      width: '1rem',
+      height: '1rem',
+    },
+  },
+})
+
+interface ImageTextBlockProps extends BrandPivotBaseBlockProps {
+  animate?: boolean
+  title_size?: FontSizes
+  title_size_mobile?: FontSizes
+  title: string
+  title_color?: MinimalColorComponent
+  show_hedvig_wordmark?: boolean
+  paragraph: MarkdownHtmlComponent
+  text_position: TextPosition
+  text_position_mobile: TextPosition
+  button_title: string
+  button_type: 'filled' | 'outlined'
+  button_link?: LinkComponent
+  show_button: boolean
+  image_type: 'image' | 'video'
+  image?: StoryblokImage
+  mobile_image?: StoryblokImage
+  use_image_link: boolean
+  image_link: LinkComponent
+  image_video_file_location?: string
+  mobile_image_video_file_location?: string
+  background_type: string
+  background_image: string
+  background_video_file_location: string
+  mobile_background_video_file_location: string
+  size: SectionSize
+  full_width: boolean
+  media_position: DisplayOrder
+  media_size_small: boolean
+  button_color?: MinimalColorComponent
+  button_position_mobile?: 'above' | 'below'
+}
+
+export const ImageTextBlock: React.FC<ImageTextBlockProps> = ({
+  animate,
+  extra_styling,
+  title_size = 'sm',
+  title_size_mobile,
+  title,
+  title_color,
+  paragraph,
+  text_position,
+  text_position_mobile,
+  button_title,
+  button_type,
+  button_link,
+  show_button,
+  image_type,
+  image,
+  mobile_image,
+  image_video_file_location,
+  mobile_image_video_file_location,
+  background_type,
+  background_image,
+  background_video_file_location,
+  mobile_background_video_file_location,
+  color,
+  size,
+  media_position,
+  media_size_small,
+  button_color,
+  button_position_mobile,
+  index,
+  show_hedvig_wordmark,
+  full_width,
+}) => {
+  const [hasRendered, setHasRendered] = useState(false)
+
+  useEffect(() => {
+    setHasRendered(true)
+  }, [])
+
+  return (
+    <SectionWrapper
+      brandPivot
+      colorComponent={color}
+      size={size}
+      backgroundImage={background_type !== 'video' ? background_image : 'none'}
+      extraStyling={extra_styling}
+    >
+      {background_type === 'video' &&
+        background_video_file_location &&
+        mobile_background_video_file_location && (
+          <BackgroundVideo
+            desktopImage={background_video_file_location}
+            mobileImage={mobile_background_video_file_location}
+            baseVideoUrl={background_video_file_location}
+            baseMobileVideoUrl={mobile_background_video_file_location}
+            backgroundColor="standard"
+          />
+        )}
+
+      <AlignableContentWrapper
+        textPosition={text_position}
+        index={index}
+        brandPivot
+        fullWidth={full_width}
+      >
+        <TextWrapper
+          textPosition={text_position}
+          textPositionMobile={text_position_mobile}
+          isBlockFullWidth={full_width}
+        >
+          <Title
+            as="h2"
+            alignment={text_position}
+            animate={animate}
+            color={title_color?.color}
+            displayorder={media_position}
+            size={title_size}
+            mobileSize={title_size_mobile}
+          >
+            <span
+              dangerouslySetInnerHTML={{
+                __html: title,
+              }}
+            />
+            {show_hedvig_wordmark && (
+              <Wordmark>
+                <HedvigSymbol />
+              </Wordmark>
+            )}
+          </Title>
+          <Paragraph
+            dangerouslySetInnerHTML={{
+              __html: paragraph.html,
+            }}
+            animate={animate}
+            colorComponent={color}
+            textPosition={text_position}
+          />
+          {hasRendered && (
+            <MediaQuery query="(min-width: 481px)">
+              <AnimatedAlignedButton
+                title={button_title}
+                type={button_type}
+                buttonLink={button_link}
+                show={show_button}
+                color={button_color}
+                size={'md'}
+                positionMobile={button_position_mobile}
+                animate={animate}
+              />
+            </MediaQuery>
+          )}
+        </TextWrapper>
+        {hasRendered && (
+          <MediaQuery query="(max-width: 480px)">
+            <AnimatedAlignedButton
+              title={button_title}
+              type={button_type}
+              buttonLink={button_link}
+              show={show_button}
+              color={button_color}
+              size={'md'}
+              positionMobile={button_position_mobile}
+              animate={animate}
+            />
+          </MediaQuery>
+        )}
+        {image && image_type !== 'video' ? (
+          mobile_image ? (
+            <>
+              {hasRendered && (
+                <>
+                  <MediaQuery query="(max-width: 480px)">
+                    <Image
+                      alignment={text_position}
+                      displayorder={media_position}
+                      smallImage={media_size_small}
+                      src={getStoryblokImage(mobile_image)}
+                    />
+                  </MediaQuery>
+                  <MediaQuery query="(min-width: 481px)">
+                    <Image
+                      alignment={text_position}
+                      displayorder={media_position}
+                      smallImage={media_size_small}
+                      src={getStoryblokImage(image)}
+                    />
+                  </MediaQuery>
+                </>
+              )}
+            </>
+          ) : (
+            <Image
+              alignment={text_position}
+              displayorder={media_position}
+              smallImage={media_size_small}
+              src={getStoryblokImage(image)}
+            />
+          )
+        ) : (
+          image_type === 'video' &&
+          image_video_file_location &&
+          mobile_image_video_file_location && (
+            <ImageVideoWrapper
+              alignment={text_position}
+              displayorder={media_position}
+              smallImage={media_size_small}
+            >
+              {hasRendered && (
+                <>
+                  <MediaQuery query="(max-width: 700px)">
+                    <ImageVideo src={mobile_image_video_file_location} />
+                  </MediaQuery>
+
+                  <MediaQuery query="(min-width: 701px)">
+                    <ImageVideo src={image_video_file_location} />
+                  </MediaQuery>
+                </>
+              )}
+            </ImageVideoWrapper>
+          )
+        )}
+      </AlignableContentWrapper>
+    </SectionWrapper>
+  )
+}

--- a/src/blocks/ImageTextBlockBrandPivot/index.tsx
+++ b/src/blocks/ImageTextBlockBrandPivot/index.tsx
@@ -27,7 +27,7 @@ import {
   Image as StoryblokImage,
 } from '../../utils/storyblok'
 import {
-  BrandPivotBaseBlockProps,
+  BaseBlockProps,
   MarkdownHtmlComponent,
   MinimalColorComponent,
 } from '../BaseBlockProps'
@@ -220,7 +220,7 @@ const Wordmark = styled('div')({
   },
 })
 
-interface ImageTextBlockProps extends BrandPivotBaseBlockProps {
+interface ImageTextBlockProps extends BaseBlockProps {
   animate?: boolean
   title_size?: FontSizes
   title_size_mobile?: FontSizes

--- a/src/blocks/InsuranceInfoBlock/InsuranceInfoBlock.tsx
+++ b/src/blocks/InsuranceInfoBlock/InsuranceInfoBlock.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/core'
 import styled from '@emotion/styled'
 import { colorsV3 } from '@hedviginsurance/brand'
 import React from 'react'
-import { BrandPivotBaseBlockProps } from 'blocks/BaseBlockProps'
+import { BaseBlockProps } from 'blocks/BaseBlockProps'
 import {
   ContentWrapper,
   LAPTOP_BP_UP,
@@ -96,7 +96,7 @@ type Values = {
   value: string
 }[]
 
-interface InsuranceInfoBlockProps extends BrandPivotBaseBlockProps {
+interface InsuranceInfoBlockProps extends BaseBlockProps {
   value_1_description: string
   value_1_value: string
   value_2_description: string

--- a/src/blocks/PerilsBlock/PerilsBlock.tsx
+++ b/src/blocks/PerilsBlock/PerilsBlock.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import React, { useState } from 'react'
 import { useLocale } from 'context/LocaleContext'
-import { BrandPivotBaseBlockProps } from 'blocks/BaseBlockProps'
+import { BaseBlockProps } from 'blocks/BaseBlockProps'
 import {
   ContentWrapper as OriginalContentWrapper,
   SectionWrapper,
@@ -16,7 +16,7 @@ export interface ContractOption {
   value: TypeOfContract
 }
 
-interface PerilsBlockProps extends BrandPivotBaseBlockProps {
+interface PerilsBlockProps extends BaseBlockProps {
   insurance_types: ContractOption[]
 }
 

--- a/src/blocks/PlainTextBlock.tsx
+++ b/src/blocks/PlainTextBlock.tsx
@@ -5,10 +5,7 @@ import {
   MOBILE_BP_UP,
   SectionWrapper,
 } from '../components/blockHelpers'
-import {
-  BrandPivotBaseBlockProps,
-  MarkdownHtmlComponent,
-} from './BaseBlockProps'
+import { BaseBlockProps, MarkdownHtmlComponent } from './BaseBlockProps'
 
 type ParagraphFontSize = 'sm' | 'md' | 'lg' | 'xl'
 
@@ -29,7 +26,7 @@ const InnerContent = styled.div<{ fontSize: ParagraphFontSize }>`
   }
 `
 
-export interface PlainTextBlockProps extends BrandPivotBaseBlockProps {
+export interface PlainTextBlockProps extends BaseBlockProps {
   content: MarkdownHtmlComponent
   font_size: ParagraphFontSize
 }

--- a/src/blocks/QuoteBlockBrandPivot/QuoteBlockBrandPivot.tsx
+++ b/src/blocks/QuoteBlockBrandPivot/QuoteBlockBrandPivot.tsx
@@ -1,17 +1,14 @@
 import styled from '@emotion/styled'
 import { fonts } from '@hedviginsurance/brand'
 import React from 'react'
-import {
-  BrandPivotBaseBlockProps,
-  MinimalColorComponent,
-} from 'blocks/BaseBlockProps'
+import { BaseBlockProps, MinimalColorComponent } from 'blocks/BaseBlockProps'
 import {
   ContentWrapper,
   getMinimalColorStyles,
   SectionWrapper,
 } from 'components/blockHelpers'
 
-export interface QuoteBlockProps extends BrandPivotBaseBlockProps {
+export interface QuoteBlockProps extends BaseBlockProps {
   quotes: ReadonlyArray<{
     _uid: string
     quote: string

--- a/src/blocks/SingleQuoteBlock.tsx
+++ b/src/blocks/SingleQuoteBlock.tsx
@@ -3,7 +3,7 @@ import { fonts } from '@hedviginsurance/brand'
 import React from 'react'
 import { ContentWrapper, SectionWrapper } from '../components/blockHelpers'
 import { textFlexPositionMap, TextPosition } from '../utils/textPosition'
-import { BaseBlockProps } from './BaseBlockProps'
+import { BaseBlockPropsDeprecated } from './BaseBlockProps'
 
 const TABLET_BP_DOWN = '@media (max-width: 850px)'
 
@@ -54,7 +54,7 @@ const Cite = styled('cite')({
   fontStyle: 'normal',
 })
 
-export interface SingleQuoteBlockProps extends BaseBlockProps {
+export interface SingleQuoteBlockProps extends BaseBlockPropsDeprecated {
   quote: string
   author: string
   is_long_quote: boolean

--- a/src/blocks/SpacerBlock.tsx
+++ b/src/blocks/SpacerBlock.tsx
@@ -1,14 +1,14 @@
 import styled from '@emotion/styled'
 import React from 'react'
 import { SectionWrapper } from '../components/blockHelpers'
-import { BrandPivotBaseBlockProps } from './BaseBlockProps'
+import { BaseBlockProps } from './BaseBlockProps'
 
 const Spacer = styled(SectionWrapper)`
   padding-bottom: 0 !important;
   z-index: 1;
 `
 
-export const SpacerBlock: React.FunctionComponent<BrandPivotBaseBlockProps> = ({
+export const SpacerBlock: React.FunctionComponent<BaseBlockProps> = ({
   size,
   color,
   extra_styling,

--- a/src/blocks/TitleParagraphBlockBrandPivot/TitleParagraphBlockBrandPivot.tsx
+++ b/src/blocks/TitleParagraphBlockBrandPivot/TitleParagraphBlockBrandPivot.tsx
@@ -5,10 +5,7 @@ import {
   MOBILE_BP_DOWN,
   SectionWrapper,
 } from '../../components/blockHelpers'
-import {
-  BrandPivotBaseBlockProps,
-  MarkdownHtmlComponent,
-} from '../BaseBlockProps'
+import { BaseBlockProps, MarkdownHtmlComponent } from '../BaseBlockProps'
 
 const Headline = styled('h4')({
   textTransform: 'uppercase',
@@ -42,7 +39,7 @@ const TitleParagraphContentWrapper = styled(ContentWrapper)({
   maxWidth: '930px',
 })
 
-export interface TitleParagraphBlockProps extends BrandPivotBaseBlockProps {
+export interface TitleParagraphBlockProps extends BaseBlockProps {
   title: string
   paragraph: MarkdownHtmlComponent
 }

--- a/src/blocks/YoutubeVideoBlock/YoutubeVideoBlock.tsx
+++ b/src/blocks/YoutubeVideoBlock/YoutubeVideoBlock.tsx
@@ -2,10 +2,7 @@ import { keyframes } from '@emotion/core'
 import styled from '@emotion/styled'
 import { colorsV3 } from '@hedviginsurance/brand'
 import React, { useEffect, useState } from 'react'
-import {
-  BrandPivotBaseBlockProps,
-  MarkdownHtmlComponent,
-} from 'blocks/BaseBlockProps'
+import { BaseBlockProps, MarkdownHtmlComponent } from 'blocks/BaseBlockProps'
 import {
   ContentWrapper,
   SectionWrapper,
@@ -109,7 +106,7 @@ const VideoFrame = styled.iframe`
   z-index: 1;
 `
 
-interface YoutubeVideoBlockProps extends BrandPivotBaseBlockProps {
+interface YoutubeVideoBlockProps extends BaseBlockProps {
   overlay_image: Image
   video_id: string
   caption?: MarkdownHtmlComponent

--- a/src/blocks/index.tsx
+++ b/src/blocks/index.tsx
@@ -15,6 +15,7 @@ import { CtaBlock } from './CtaBlock/CtaBlock'
 import { HeaderBlock } from './HeaderBlockBrandPivot'
 import { HeadlineBlock } from './HeadlineBlock/HeadlineBlock'
 import { ImageBlockBrandPivot } from './ImageBlockBrandPivot/ImageBlockBrandPivot'
+import { ImageBlock } from './ImageBlock/ImageBlock'
 import { InsuranceInfoBlock } from './InsuranceInfoBlock/InsuranceInfoBlock'
 import { PerilsBlock } from './PerilsBlock/PerilsBlock'
 import { PlainTextBlock } from './PlainTextBlock'
@@ -41,6 +42,7 @@ const blockComponents = {
   quote_block: QuoteBlockBrandPivot,
   single_quote_block: SingleQuoteBlock,
   image_block_brand_pivot: ImageBlockBrandPivot,
+  image_block: ImageBlock,
   insurance_info_block: InsuranceInfoBlock,
   title_paragraph_block_brand_pivot: TitleParagraphBlockBrandPivot,
   background_video_block: BackgroundVideoBlock,

--- a/src/blocks/index.tsx
+++ b/src/blocks/index.tsx
@@ -3,12 +3,13 @@ import { ColumnTextBlock } from 'blocks/ColumnTextBlock/ColumnTextBlock'
 import { HeroBlock } from 'blocks/HeroBlock/HeroBlock'
 import { HeroImageBlockBrandPivot } from 'blocks/HeroImageBlockBrandPivot/HeroImageBlockBrandPivot'
 import { ImageTextBlockBrandPivot } from 'blocks/ImageTextBlockBrandPivot'
+import { ImageTextBlock } from 'blocks/ImageTextBlock'
 import { YoutubeVideoBlock } from 'blocks/YoutubeVideoBlock/YoutubeVideoBlock'
 import { AccordionBlock } from './AccordionBlock/AccordionBlock'
 import { AppButtonsBlock } from './AppButtonsBlock'
 import { BackgroundVideoBlock } from './BackgroundVideoBlock'
 import { BannerBlock } from './BannerBlock/BannerBlock'
-import { BaseBlockProps } from './BaseBlockProps'
+import { BaseBlockPropsDeprecated } from './BaseBlockProps'
 import { BulletPointBlock } from './BulletPointBlock/BulletPointBlock'
 import { CtaBlock } from './CtaBlock/CtaBlock'
 import { HeaderBlock } from './HeaderBlockBrandPivot'
@@ -33,6 +34,7 @@ const blockComponents = {
   column_text_block: ColumnTextBlock,
   cta_block: CtaBlock,
   image_text_block_brand_pivot: ImageTextBlockBrandPivot,
+  image_text_block: ImageTextBlock,
   headline_block: HeadlineBlock,
   hero_block: HeroBlock,
   hero_image_block_brand_pivot: HeroImageBlockBrandPivot,
@@ -52,7 +54,7 @@ const blockComponents = {
 
 export const getBlockComponent = <
   TBlockType extends keyof typeof blockComponents,
-  TBlockProps extends BaseBlockProps
+  TBlockProps extends BaseBlockPropsDeprecated
 >(
   blockType: string | TBlockType,
 ):

--- a/src/pages/StoryPage.tsx
+++ b/src/pages/StoryPage.tsx
@@ -3,7 +3,7 @@ import Helmet from 'react-helmet-async'
 import { useLocale } from 'context/LocaleContext'
 import SbEditable from 'patched/storyblok-react'
 import { getBlockComponent } from '../blocks'
-import { BaseBlockProps } from '../blocks/BaseBlockProps'
+import { BaseBlockPropsDeprecated } from '../blocks/BaseBlockProps'
 import { FooterBlock } from '../blocks/FooterBlock/FooterBlock'
 import {
   BodyStory,
@@ -32,7 +32,7 @@ export const StoryPage: React.FunctionComponent<{ nonce?: string }> = ({
           </GlobalStoryContainer>
           {getBlocksOrDefault(story!).map((block, index) => {
             const BlockComponent:
-              | React.ComponentType<BaseBlockProps & any>
+              | React.ComponentType<BaseBlockPropsDeprecated & any>
               | undefined = getBlockComponent(block.component)
             if (!BlockComponent) {
               return null

--- a/src/storyblok/StoryContainer.tsx
+++ b/src/storyblok/StoryContainer.tsx
@@ -1,7 +1,7 @@
 import { Container } from 'constate'
 import React, { PureComponent } from 'react'
 import {
-  BaseBlockProps,
+  BaseBlockPropsDeprecated,
   MinimalColorComponent,
   MarkdownHtmlComponent,
 } from '../blocks/BaseBlockProps'
@@ -60,7 +60,7 @@ export interface BodyStory extends Story {
       _uid: string
       page_title: string
       component: 'page'
-      body: ReadonlyArray<BaseBlockProps>
+      body: ReadonlyArray<BaseBlockPropsDeprecated>
       hide_footer?: boolean
     }
 }


### PR DESCRIPTION
## What?
Getting rid of the BrandPivot suffix component by component :) The steps are to duplicate the existing components and remove the BrandPivot name. Then deploy it and change the name in the Storyblok admin and it will be migrated to the new name. Once that is done we can make a new PR and remove the deprecated component.

Note: The blocks are not new, simply duplicated and renamed so don't look to much on the code, there will be a time to refactor :) 

- Rename ImageTextBlockBrandPivot
- Rename ImageBlockBrandPivot
- Rename BaseBlockProps

## Why?
🧹

