### PR TITLE
Make menu labels clickable

### DIFF
--- a/src/blocks/HeaderBlock/MenuItem.tsx
+++ b/src/blocks/HeaderBlock/MenuItem.tsx
@@ -87,13 +87,14 @@ const GroupLabelListItem = styled(MenuListItem)({
   fontSize: '0.75rem',
 })
 
-const MenuGroupLabel = styled('span')({
+const MenuGroupLabel = styled('a')<{ as?: 'a' | 'span' }>({
   display: 'block',
   color: colorsV3.gray700,
   textTransform: 'uppercase',
   lineHeight: '1rem',
   whiteSpace: 'nowrap',
   paddingBottom: '1rem',
+  textDecoration: 'none',
 
   [TABLET_BP_DOWN]: {
     display: 'inline-block',
@@ -273,14 +274,22 @@ export const MenuItem: React.FunctionComponent<{ menuItem: MenuItemType }> = ({
                     isClosing={isClosing}
                     hasMenuGroups={true}
                   >
-                    {menu_item_groups.map(({ label, menu_items, _uid }) => (
-                      <DropdownMenuItemList key={_uid}>
-                        <GroupLabelListItem>
-                          <MenuGroupLabel>{label}</MenuGroupLabel>
-                        </GroupLabelListItem>
-                        <SubMenuLinks menu_items={menu_items} />
-                      </DropdownMenuItemList>
-                    ))}
+                    {menu_item_groups.map(
+                      ({ label, link, menu_items, _uid }) => (
+                        <DropdownMenuItemList key={_uid}>
+                          <GroupLabelListItem>
+                            {link?.cached_url ? (
+                              <MenuGroupLabel href={getStoryblokLinkUrl(link)}>
+                                {label}
+                              </MenuGroupLabel>
+                            ) : (
+                              <MenuGroupLabel as="span">{label}</MenuGroupLabel>
+                            )}
+                          </GroupLabelListItem>
+                          <SubMenuLinks menu_items={menu_items} />
+                        </DropdownMenuItemList>
+                      ),
+                    )}
                   </DropdownMenuContainer>
                 )}
               </AnimateHeight>

--- a/src/blocks/HeaderBlock/MenuItem.tsx
+++ b/src/blocks/HeaderBlock/MenuItem.tsx
@@ -87,7 +87,7 @@ const GroupLabelListItem = styled(MenuListItem)({
   fontSize: '0.75rem',
 })
 
-const MenuGroupLabel = styled('a')<{ as?: 'a' | 'span' }>({
+const MenuGroupLabel = styled('a')<{ as?: 'span' }>({
   display: 'block',
   color: colorsV3.gray700,
   textTransform: 'uppercase',

--- a/src/storyblok/StoryContainer.tsx
+++ b/src/storyblok/StoryContainer.tsx
@@ -88,6 +88,7 @@ export interface MenuItem {
 export interface MenuItemGroup {
   _uid: string
   label: string
+  link?: LinkComponent
   menu_items: ReadonlyArray<MenuItem>
 }
 

--- a/storyblok/components.json
+++ b/storyblok/components.json
@@ -2465,6 +2465,10 @@
           "pos": 0,
           "translatable": false
         },
+        "link": {
+          "type": "multilink",
+          "pos": 1
+        },
         "menu_items": {
           "type": "bloks",
           "translatable": true,


### PR DESCRIPTION
## What?
Make menu group labels linkable


## Why?
We have landing pages for Home insurance and should therefore have it's own menu link

## Screenshots / recordings 

https://user-images.githubusercontent.com/6661511/157471425-e6167988-ad5c-42e1-bdb8-71dc113980df.mov

