### PR TITLE
Fix/header menu link color

### DIFF
--- a/src/blocks/HeaderBlock/MenuItem.tsx
+++ b/src/blocks/HeaderBlock/MenuItem.tsx
@@ -67,21 +67,24 @@ const DropdownMenuItemList = styled('ul')({
   },
 })
 
-const MenuLink = styled('a')({
-  color: 'inherit',
-  textDecoration: 'none',
+const MenuLink = styled('a')<{ inverseColor?: boolean }>(
+  ({ inverseColor }) => ({
+    color: inverseColor ? colorsV3.gray100 : colorsV3.gray900,
+    textDecoration: 'none',
+    transition: 'color 300ms',
 
-  [TABLET_BP_DOWN]: {
-    display: 'inline-block',
-    padding: `1rem 0.5rem 1rem 2rem`,
-    fontFamily: fonts.FAVORIT,
-    fontSize: '1.5rem',
-  },
+    [TABLET_BP_DOWN]: {
+      display: 'inline-block',
+      padding: `1rem 0.5rem 1rem 2rem`,
+      fontFamily: fonts.FAVORIT,
+      fontSize: '1.5rem',
+    },
 
-  [MOBILE_BP_DOWN]: {
-    paddingLeft: '1.5rem',
-  },
-})
+    [MOBILE_BP_DOWN]: {
+      paddingLeft: '1.5rem',
+    },
+  }),
+)
 
 const GroupLabelListItem = styled(MenuListItem)({
   fontSize: '0.75rem',
@@ -174,9 +177,10 @@ export const SubMenuLinks: React.FC<{
   </>
 )
 
-export const MenuItem: React.FunctionComponent<{ menuItem: MenuItemType }> = ({
-  menuItem,
-}) => {
+export const MenuItem: React.FunctionComponent<{
+  menuItem: MenuItemType
+  inverseColor: boolean
+}> = ({ menuItem, inverseColor }) => {
   const { menu_items = [], menu_item_groups = [] } = menuItem
   const hasSubMenuItems = menu_items.length > 0
   const hasSubMenuGroups = menu_item_groups.length > 0
@@ -243,11 +247,16 @@ export const MenuItem: React.FunctionComponent<{ menuItem: MenuItemType }> = ({
           onMouseOut={() => close()}
         >
           {menuItem.link && menuItem.link.cached_url ? (
-            <MenuLink href={getStoryblokLinkUrl(menuItem.link)}>
+            <MenuLink
+              inverseColor={inverseColor}
+              href={getStoryblokLinkUrl(menuItem.link)}
+            >
               {menuItem.label}
             </MenuLink>
           ) : (
-            <MenuFakeLink>{menuItem.label}</MenuFakeLink>
+            <MenuFakeLink inverseColor={inverseColor}>
+              {menuItem.label}
+            </MenuFakeLink>
           )}
 
           {hasSubMenus && (

--- a/src/blocks/HeaderBlock/index.tsx
+++ b/src/blocks/HeaderBlock/index.tsx
@@ -29,19 +29,11 @@ export const TOGGLE_TRANSITION_TIME = 250
 const isBelowScrollThreshold = () =>
   typeof window !== 'undefined' && window.scrollY > 20
 
-const HeaderWrapper = styled('header')<{
-  inverse: boolean
-}>(({ inverse }) => ({
+const HeaderWrapper = styled('header')({
   position: 'sticky',
   top: 0,
   zIndex: 100,
-  color: inverse ? colorsV3.gray100 : colorsV3.gray900,
-  transition: 'color 300ms',
-
-  [TABLET_BP_DOWN]: {
-    color: colorsV3.gray100,
-  },
-}))
+})
 
 const HeaderMain = styled('div')<{
   inverse: boolean
@@ -159,14 +151,17 @@ const MobileLogo = styled('div')({
   },
 })
 
-const LogoLink = styled('a')({
+const LogoLink = styled('a')<{
+  inverse: boolean
+}>(({ inverse }) => ({
   display: 'flex',
-  color: 'inherit',
+  color: inverse ? colorsV3.gray100 : colorsV3.gray900,
+  transition: 'color 300ms',
 
   svg: {
     height: '100%',
   },
-})
+}))
 
 const ButtonWrapper = styled('div')({
   paddingLeft: '2rem',
@@ -252,6 +247,9 @@ export const Header: React.FC<{ story: GlobalStory } & HeaderBlockProps> = (
       : props.cta_color?.color,
   )
 
+  const inverseColor =
+    props.is_transparent && props.inverse_colors && !isBelowThreshold
+
   const updateHeader = useCallback(() => {
     if (isBelowScrollThreshold()) {
       setIsBelowThreshold(true)
@@ -287,20 +285,12 @@ export const Header: React.FC<{ story: GlobalStory } & HeaderBlockProps> = (
           text={props.story.content.banner_text}
         />
       )}
-      <HeaderWrapper
-        inverse={
-          props.is_transparent && props.inverse_colors && !isBelowThreshold
-        }
-      >
+      <HeaderWrapper>
         {!props.is_transparent && <Filler />}
         <Togglable>
           {({ isOpen, isClosing, toggleOpen }) => (
             <HeaderMain
-              inverse={
-                props.is_transparent &&
-                props.inverse_colors &&
-                !isBelowThreshold
-              }
+              inverse={inverseColor}
               open={isOpen || isClosing}
               sticky={isBelowThreshold}
             >
@@ -318,7 +308,10 @@ export const Header: React.FC<{ story: GlobalStory } & HeaderBlockProps> = (
                     />
 
                     <DesktopLogo>
-                      <LogoLink href={'/' + currentLocale.label}>
+                      <LogoLink
+                        inverse={inverseColor}
+                        href={'/' + currentLocale.label}
+                      >
                         <HedvigLogo width={94} />
                       </LogoLink>
                     </DesktopLogo>
@@ -334,7 +327,11 @@ export const Header: React.FC<{ story: GlobalStory } & HeaderBlockProps> = (
                       <MenuList open={isOpen}>
                         {(props.story.content.header_menu_items ?? []).map(
                           (menuItem) => (
-                            <MenuItem menuItem={menuItem} key={menuItem._uid} />
+                            <MenuItem
+                              inverseColor={inverseColor}
+                              menuItem={menuItem}
+                              key={menuItem._uid}
+                            />
                           ),
                         )}
                       </MenuList>

--- a/src/blocks/HeaderBlock/index.tsx
+++ b/src/blocks/HeaderBlock/index.tsx
@@ -160,8 +160,12 @@ const MobileLogo = styled('div')({
 })
 
 const LogoLink = styled('a')({
-  display: 'inline-flex',
+  display: 'flex',
   color: 'inherit',
+
+  svg: {
+    height: '100%',
+  },
 })
 
 const ButtonWrapper = styled('div')({


### PR DESCRIPTION
## What?
- Fix the bug where links in header menu didn't change color on scroll in Chrome
- Fix logo height bug in Safari desktop

## Why?
The bug is that Chrome don't respect the `color: inherit` rule for visited links. It doesn't help if you explicitly set the color on `a:visited` links to inherit. If you visit the site in incognito mode or for the first time the links will update as they should, that's the reason for inconsistent behaviour between users.

So the solution is to set the color explicitly on these links.

## Before

https://user-images.githubusercontent.com/6661511/158408777-bf0a2c0d-95f6-4d3f-bcc7-4d89d37e4a49.mov

## After
https://user-images.githubusercontent.com/6661511/158409374-51092bb4-83dd-4358-9946-f9354f28ebe8.mov



