### PR TITLE
Make sure mobile menu has a set color

### DIFF
--- a/src/blocks/HeaderBlock/MenuItem.tsx
+++ b/src/blocks/HeaderBlock/MenuItem.tsx
@@ -78,6 +78,7 @@ const MenuLink = styled('a')<{ inverseColor?: boolean }>(
       padding: `1rem 0.5rem 1rem 2rem`,
       fontFamily: fonts.FAVORIT,
       fontSize: '1.5rem',
+      color: colorsV3.gray100,
     },
 
     [MOBILE_BP_DOWN]: {


### PR DESCRIPTION
## What?
Forgot to set a fixed color for the mobile menu


## Why?
This caused the menu links to be same color as the background

### Before
<img width="389" alt="Screenshot 2022-03-16 at 17 24 01" src="https://user-images.githubusercontent.com/6661511/158638882-1f3c2031-67de-41b9-97a5-6d8ec987ab2e.png">

### After
<img width="386" alt="Screenshot 2022-03-16 at 17 24 10" src="https://user-images.githubusercontent.com/6661511/158638902-159b13b7-e592-4d36-a8cf-989a28671f53.png">

