### PR TITLE
Don't render tabs for single set of Perils

### DIFF
--- a/src/components/Perils/index.tsx
+++ b/src/components/Perils/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 import { minimalColorComponentColors } from 'src/blocks/BaseBlockProps'
 import { GlobalStory } from 'storyblok/StoryContainer'
 import { Tabs } from '../Tabs/Tabs'
@@ -16,9 +16,20 @@ export const Perils: React.FC<Props> = ({
   perilsCollections,
   story,
 }) => {
-  const tabItems = useMemo(
-    () =>
-      perilsCollections.map((perilsCollection: PerilsCollection) => ({
+  if (perilsCollections.length === 1) {
+    return (
+      <PerilCollection
+        key={perilsCollections[0].id}
+        perils={perilsCollections[0].items}
+        story={story}
+        color={color}
+      />
+    )
+  }
+
+  return (
+    <Tabs
+      items={perilsCollections.map((perilsCollection: PerilsCollection) => ({
         id: perilsCollection.id,
         name: perilsCollection.label,
         content: (
@@ -29,9 +40,7 @@ export const Perils: React.FC<Props> = ({
             color={color}
           />
         ),
-      })),
-    [color, perilsCollections, story],
+      }))}
+    />
   )
-
-  return <Tabs items={tabItems} />
 }


### PR DESCRIPTION
<!-- 
To link the branch/PR to a Jira issue either
1. (preferred) add the issue key to the name of your branch (e.g. GRW-123/fix/some-annoying-bug)
2. prefix your PR title with it

Also, if applicable, include whether this is a Fix, Feature or Chore.

Example PR title: GRW-123 / Feature / Awesome new thing
-->

## What?
Don't render tabs for single set of Perils


## Why?
No need for tab navigation for a single set :) 


https://user-images.githubusercontent.com/6661511/167378117-e5e5f42c-2aba-4ea4-9cac-294d6ac6fa60.mov


