### PR TITLE
Fix / Alignment peril icons

### DIFF
--- a/src/components/Perils/PerilItem/PerilItem.tsx
+++ b/src/components/Perils/PerilItem/PerilItem.tsx
@@ -104,9 +104,6 @@ const IconWrapper = styled.div`
   svg {
     width: 100%;
     height: 100%;
-    ${TABLET_BP_UP} {
-      transform: translateX(-0.625rem);
-    }
   }
 `
 


### PR DESCRIPTION
## What?
Fix alignment for peril icons


## Why?
The had a transform to offset it slightly. This was actually from a legacy design so not applicable anymore.

https://user-images.githubusercontent.com/6661511/167417046-5410ed6c-bdff-487f-806a-19bac34e0aaf.mov


