### PR TITLE
GRW-1063 / Feat / Disabled perils

### DIFF
--- a/src/components/Perils/PerilCollection/PerilCollection.tsx
+++ b/src/components/Perils/PerilCollection/PerilCollection.tsx
@@ -14,6 +14,7 @@ type Props = {
 export const PerilCollection: React.FC<Props> = ({ perils, story, color }) => {
   const [isShowingPeril, setIsShowingPeril] = useState(false)
   const [currentPeril, setCurrentPeril] = useState(0)
+  const enabledPerils = perils.filter((peril) => !peril.disabled)
   return (
     <>
       <PerilList
@@ -22,9 +23,9 @@ export const PerilCollection: React.FC<Props> = ({ perils, story, color }) => {
         setCurrentPeril={setCurrentPeril}
         setIsShowingPeril={setIsShowingPeril}
       />
-      {perils.length > 0 && (
+      {enabledPerils.length > 0 && (
         <PerilModal
-          perils={perils}
+          perils={enabledPerils}
           currentPerilIndex={currentPeril}
           setCurrentPeril={setCurrentPeril}
           isVisible={isShowingPeril}

--- a/src/components/Perils/PerilItem/PerilItem.stories.tsx
+++ b/src/components/Perils/PerilItem/PerilItem.stories.tsx
@@ -26,3 +26,15 @@ export const Default = () => (
     />
   </div>
 )
+
+export const Disabled = () => (
+  <div style={{ maxWidth: '184px', margin: 'auto' }}>
+    <PerilItem
+      title={peril.title}
+      color="standard"
+      disabled={true}
+      icon={peril.icon}
+      onClick={action('click')}
+    />
+  </div>
+)

--- a/src/components/Perils/PerilItem/PerilItem.stories.tsx
+++ b/src/components/Perils/PerilItem/PerilItem.stories.tsx
@@ -17,7 +17,7 @@ export default {
 const peril = brfPerils[0].items[0]
 
 export const Default = () => (
-  <div style={{ maxWidth: '290px' }}>
+  <div style={{ maxWidth: '184px', margin: 'auto' }}>
     <PerilItem
       title={peril.title}
       color="standard"

--- a/src/components/Perils/PerilItem/PerilItem.tsx
+++ b/src/components/Perils/PerilItem/PerilItem.tsx
@@ -114,7 +114,6 @@ const IconWrapper = styled.div`
   svg {
     width: 100%;
     height: 100%;
-    fill: currentColor;
   }
 `
 

--- a/src/components/Perils/PerilItem/PerilItem.tsx
+++ b/src/components/Perils/PerilItem/PerilItem.tsx
@@ -13,6 +13,7 @@ import { useIcon } from '../data/useIcon'
 interface PerilItemProps {
   title: React.ReactNode
   color: minimalColorComponentColors
+  disabled?: boolean
   icon: PerilIcon
   onClick: () => void
 }
@@ -36,7 +37,9 @@ const OuterContainer = styled.div`
   }
 `
 
-const InnerContainer = styled.button<{ color: minimalColorComponentColors }>`
+const InnerContainer = styled.button<{
+  color: minimalColorComponentColors
+}>`
   display: flex;
   width: 100%;
   align-items: center;
@@ -47,12 +50,19 @@ const InnerContainer = styled.button<{ color: minimalColorComponentColors }>`
   color: inherit;
   font-family: inherit;
   border-radius: 0.375rem;
-  background-color: ${({ color }) =>
-    color === 'standard-inverse' ? colorsV3.gray100 : colorsV3.white};
+  background-color: ${colorsV3.white};
   border: 0;
+  box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.1);
   cursor: pointer;
   transition: all 150ms ease-in-out;
   appearance: none;
+
+  &:disabled {
+    color: ${colorsV3.gray500};
+    background-color: ${colorsV3.gray100};
+    border: 1px solid ${colorsV3.gray300};
+    cursor: initial;
+  }
 
   ${TABLET_BP_UP} {
     position: absolute;
@@ -68,7 +78,7 @@ const InnerContainer = styled.button<{ color: minimalColorComponentColors }>`
     align-items: flex-start;
     justify-content: space-between;
 
-    &:hover {
+    &:not([disabled]):hover {
       box-shadow: 0 0 16px rgba(0, 0, 0, 0.08);
       transform: translateY(-2px);
     }
@@ -78,7 +88,7 @@ const InnerContainer = styled.button<{ color: minimalColorComponentColors }>`
     outline: none;
   }
 
-  &:active {
+  &:not([disabled]):active {
     background-color: ${colorsV3.gray300};
     box-shadow: none;
   }
@@ -104,6 +114,7 @@ const IconWrapper = styled.div`
   svg {
     width: 100%;
     height: 100%;
+    fill: currentColor;
   }
 `
 
@@ -119,6 +130,7 @@ const Title = styled('h4')`
 export const PerilItem: React.FC<PerilItemProps> = ({
   title,
   color,
+  disabled,
   icon,
   onClick,
 }) => {
@@ -127,7 +139,7 @@ export const PerilItem: React.FC<PerilItemProps> = ({
 
   return (
     <OuterContainer>
-      <InnerContainer color={color} onClick={onClick}>
+      <InnerContainer color={color} disabled={disabled} onClick={onClick}>
         <IconWrapper dangerouslySetInnerHTML={{ __html: iconString }} />
         <Title>{title}</Title>
       </InnerContainer>

--- a/src/components/Perils/PerilList/PerilList.stories.tsx
+++ b/src/components/Perils/PerilList/PerilList.stories.tsx
@@ -4,7 +4,7 @@ import { brfPerils } from '../perilMockData/brf'
 import { PerilList } from './PerilList'
 
 export default {
-  title: 'Components/Perils/PerilCollection',
+  title: 'Components/Perils/PerilList',
   component: PerilList,
   decorators: [withKnobs],
   parameters: {
@@ -16,10 +16,12 @@ export default {
 }
 
 export const Default = () => (
-  <PerilList
-    color="standard"
-    perils={brfPerils[0].items}
-    setCurrentPeril={() => 1}
-    setIsShowingPeril={() => true}
-  />
+  <div style={{ maxWidth: '800px', margin: 'auto' }}>
+    <PerilList
+      color="standard"
+      perils={brfPerils[0].items}
+      setCurrentPeril={() => 1}
+      setIsShowingPeril={() => true}
+    />
+  </div>
 )

--- a/src/components/Perils/PerilList/PerilList.tsx
+++ b/src/components/Perils/PerilList/PerilList.tsx
@@ -51,6 +51,7 @@ export const PerilList = ({
       <PerilItem
         key={peril.title?.toString() || 'unknown'}
         color={color}
+        disabled={peril.disabled}
         title={peril.title}
         icon={peril.icon}
         onClick={() => {

--- a/src/components/Perils/perilMockData/multiplePromises.tsx
+++ b/src/components/Perils/perilMockData/multiplePromises.tsx
@@ -219,6 +219,7 @@ export const mockPerils: PerilsCollection[] = [
       },
       {
         title: 'Assault',
+        disabled: true,
         info:
           'How you act in various situations affects the level of compensation. If you intervene in a fight or if you are under the influence of alcohol or drugs, then compensation will be lowered or of zero value.',
         covered: [
@@ -247,6 +248,7 @@ export const mockPerils: PerilsCollection[] = [
       },
       {
         title: 'Travel illness',
+        disabled: true,
         info:
           'Always contact us directly through our app or by calling Hedvig Global Assistance on +45 38 48 94 61.',
         covered: [
@@ -275,6 +277,7 @@ export const mockPerils: PerilsCollection[] = [
       },
       {
         title: 'White goods',
+        disabled: true,
         info: "There's nothing special for you to think about.",
         covered: [
           'White goods/home appliances due to short circuit, over voltage or high voltage',
@@ -304,6 +307,7 @@ export const mockPerils: PerilsCollection[] = [
       },
       {
         title: 'All-risk',
+        disabled: true,
         info:
           "Take your mobile phone (theft-prone property) with you when leaving your car. Don't leave valuable property in your basement (ancillary space). If you check-in jewelry or watches in your bag while travelling, we will not be able to compensate you if they are lost.",
         covered: [
@@ -334,6 +338,7 @@ export const mockPerils: PerilsCollection[] = [
       },
       {
         title: 'Tenant ownership',
+        disabled: true,
         info: "There's nothing special for you to think about",
         covered: [
           'Water or fire damage on interior, e.g. your new kitchen',

--- a/src/components/Perils/types.ts
+++ b/src/components/Perils/types.ts
@@ -15,6 +15,7 @@ export type PerilIcon = {
 
 export type Peril = {
   title: ReactNode
+  disabled?: boolean
   description?: string
   covered: string[]
   exceptions: string[]


### PR DESCRIPTION
## What?
Add disabled Perils styling

## Why?
Highlight the difference between insurances

I will talk to Mange to see how we make the icons work. Right now they are exported a bit different so we can't control the fill properly.

What's pending:
- Icons will be updated so we can just change to `fill: currentColor`
- Adam is working on adding a checkbox to PCMS to mark a Perils as disabled 

https://user-images.githubusercontent.com/6661511/167842984-199013e6-7e35-4ff6-8b87-e42df7baa8e7.mov

### Design from Figma

https://www.figma.com/file/kuVQmKybXx4xridPkzVLnD/Car-Insurance-roll-out?node-id=650%3A9178


