### PR TITLE
GRW-1085 / Feat / add TableBlock

### DIFF
--- a/src/blocks/TableBlock/TableBlock.tsx
+++ b/src/blocks/TableBlock/TableBlock.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { colorsV3 } from '@hedviginsurance/brand'
+import styled from '@emotion/styled'
 import {
   Table,
   TableBody,
@@ -7,23 +8,60 @@ import {
   TableHead,
   TableRow,
 } from 'components/Table/Table'
-import { SectionWrapper, ContentWrapper } from 'components/blockHelpers'
+import {
+  SectionWrapper,
+  ContentWrapper,
+  TABLET_BP_UP,
+} from 'components/blockHelpers'
 import { Tick } from 'components/icons/Tick'
-import { Dash } from 'src/components/icons/Dash'
+import { Dash } from 'components/icons/Dash'
+import { Heading } from 'components/Heading/Heading'
 import { BaseBlockProps } from '../BaseBlockProps'
 
 type TableBlockProps = BaseBlockProps & {
+  title?: string
+  text?: string
   table: any
 }
+
+const TableHeader = styled.div({
+  '&:not(:empty)': {
+    marginBottom: '1rem',
+
+    [TABLET_BP_UP]: {
+      marginBottom: '2rem',
+    },
+  },
+})
+
+const Text = styled.p({
+  fontSize: '1rem',
+  textAlign: 'center',
+})
 
 const getCellIcon = (cell: string) => {
   return Number(cell) ? <Tick /> : <Dash fill={colorsV3.gray400} />
 }
 
-export const TableBlock = ({ color, index, size, table }: TableBlockProps) => {
+export const TableBlock = ({
+  color,
+  index,
+  text,
+  size,
+  title,
+  table,
+}: TableBlockProps) => {
   return (
     <SectionWrapper colorComponent={color} size={size} brandPivot>
       <ContentWrapper brandPivot index={index}>
+        <TableHeader>
+          {title && (
+            <Heading as="h3" mobileSize="sm" size="xs" textPosition="center">
+              {title}
+            </Heading>
+          )}
+          {text && <Text>{text}</Text>}
+        </TableHeader>
         <Table fullWidth>
           {table.thead && (
             <TableHead>

--- a/src/blocks/TableBlock/TableBlock.tsx
+++ b/src/blocks/TableBlock/TableBlock.tsx
@@ -18,10 +18,25 @@ import { Dash } from 'components/icons/Dash'
 import { Heading } from 'components/Heading/Heading'
 import { BaseBlockProps } from '../BaseBlockProps'
 
+type TableCell = {
+  value: string
+  _uid: string
+}
+
+type TableRow = {
+  body: TableCell[]
+  _uid: string
+}
+
+type TableType = {
+  thead: TableCell[]
+  tbody: TableRow[]
+}
+
 type TableBlockProps = BaseBlockProps & {
   title?: string
   text?: string
-  table: any
+  table: TableType
 }
 
 const TableHeader = styled.div({
@@ -66,7 +81,7 @@ export const TableBlock = ({
           {table.thead && (
             <TableHead>
               <TableRow>
-                {table.thead.map((cell: any, cellIndex: number) => (
+                {table.thead.map((cell: TableCell, cellIndex: number) => (
                   <TableCell
                     key={cell._uid}
                     align={cellIndex === 0 ? 'left' : 'center'}
@@ -79,9 +94,9 @@ export const TableBlock = ({
           )}
           {table.tbody && (
             <TableBody>
-              {table.tbody.map((row: any) => (
+              {table.tbody.map((row: TableRow) => (
                 <TableRow key={row._uid}>
-                  {row.body.map((cell: any, cellIndex: number) => (
+                  {row.body.map((cell: TableCell, cellIndex: number) => (
                     <TableCell
                       key={cell._uid}
                       align={cellIndex === 0 ? 'left' : 'center'}

--- a/src/blocks/TableBlock/TableBlock.tsx
+++ b/src/blocks/TableBlock/TableBlock.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+} from 'components/Table/Table'
+import { SectionWrapper, ContentWrapper } from 'components/blockHelpers'
+import { BaseBlockProps } from '../BaseBlockProps'
+
+type TableBlockProps = BaseBlockProps & {
+  table: any
+}
+
+export const TableBlock = ({ color, index, size, table }: TableBlockProps) => {
+  return (
+    <SectionWrapper colorComponent={color} size={size} brandPivot>
+      <ContentWrapper brandPivot index={index}>
+        <Table fullWidth>
+          {table.thead && (
+            <TableHead>
+              <TableRow>
+                {table.thead.map((cell: any, cellIndex: number) => (
+                  <TableCell
+                    key={cell._uid}
+                    align={cellIndex === 0 ? 'left' : 'center'}
+                  >
+                    {cell.value}
+                  </TableCell>
+                ))}
+              </TableRow>
+            </TableHead>
+          )}
+          {table.tbody && (
+            <TableBody>
+              {table.tbody.map((row: any) => (
+                <TableRow key={row._uid}>
+                  {row.body.map((cell: any, cellIndex: number) => (
+                    <TableCell
+                      key={cell._uid}
+                      align={cellIndex === 0 ? 'left' : 'center'}
+                    >
+                      {cell.value}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))}
+            </TableBody>
+          )}
+        </Table>
+      </ContentWrapper>
+    </SectionWrapper>
+  )
+}

--- a/src/blocks/TableBlock/TableBlock.tsx
+++ b/src/blocks/TableBlock/TableBlock.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { colorsV3 } from '@hedviginsurance/brand'
 import {
   Table,
   TableBody,
@@ -7,10 +8,16 @@ import {
   TableRow,
 } from 'components/Table/Table'
 import { SectionWrapper, ContentWrapper } from 'components/blockHelpers'
+import { Tick } from 'components/icons/Tick'
+import { Dash } from 'src/components/icons/Dash'
 import { BaseBlockProps } from '../BaseBlockProps'
 
 type TableBlockProps = BaseBlockProps & {
   table: any
+}
+
+const getCellIcon = (cell: string) => {
+  return Number(cell) ? <Tick /> : <Dash fill={colorsV3.gray400} />
 }
 
 export const TableBlock = ({ color, index, size, table }: TableBlockProps) => {
@@ -41,7 +48,7 @@ export const TableBlock = ({ color, index, size, table }: TableBlockProps) => {
                       key={cell._uid}
                       align={cellIndex === 0 ? 'left' : 'center'}
                     >
-                      {cell.value}
+                      {cellIndex === 0 ? cell.value : getCellIcon(cell.value)}
                     </TableCell>
                   ))}
                 </TableRow>

--- a/src/blocks/index.tsx
+++ b/src/blocks/index.tsx
@@ -22,6 +22,7 @@ import { QuoteBlock } from './QuoteBlock/QuoteBlock'
 import { SingleQuoteBlock } from './SingleQuoteBlock'
 import { SpacerBlock } from './SpacerBlock'
 import { TrustpilotBlock } from './TrustpilotBlock/TrustpilotBlock'
+import { TableBlock } from './TableBlock/TableBlock'
 
 const blockComponents = {
   app_buttons_block: AppButtonsBlock,
@@ -49,6 +50,7 @@ const blockComponents = {
   perils_block: PerilsBlock,
   spacer_block: SpacerBlock,
   spacer_block_brand_pivot: SpacerBlock,
+  table_block: TableBlock,
   trustpilot_block: TrustpilotBlock,
   youtube_video_block: YoutubeVideoBlock,
 }

--- a/src/components/icons/Dash.tsx
+++ b/src/components/icons/Dash.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { Svg, SvgProps } from './Svg'
+
+export const Dash = ({ fill, size, ...rest }: SvgProps) => (
+  <Svg viewBox="0 0 20 20" fill={fill} size={size} {...rest}>
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M20 10.875H0V9.625H20V10.875Z"
+    />
+  </Svg>
+)

--- a/storyblok/components.json
+++ b/storyblok/components.json
@@ -3058,6 +3058,68 @@
       "icon": null
     },
     {
+      "name": "table_block",
+      "display_name": null,
+      "schema": {
+        "title": {
+          "type": "text",
+          "pos": 0
+        },
+        "text": {
+          "type": "text",
+          "pos": 1
+        },
+        "table": {
+          "type": "table",
+          "pos": 2
+        },
+        "size": {
+          "type": "option",
+          "min_options": "",
+          "use_uuid": true,
+          "options": [
+            {
+              "value": "none",
+              "name": "None"
+            },
+            {
+              "value": "xs",
+              "name": "XS"
+            },
+            {
+              "value": "sm",
+              "name": "SM"
+            },
+            {
+              "value": "md",
+              "name": "MD"
+            },
+            {
+              "value": "lg",
+              "name": "LG"
+            },
+            {
+              "value": "xl",
+              "name": "XL"
+            }
+          ],
+          "default_value": "sm",
+          "pos": 3
+        }
+      },
+      "image": null,
+      "preview_field": null,
+      "is_root": false,
+      "preview_tmpl": null,
+      "is_nestable": true,
+      "all_presets": [],
+      "preset_id": null,
+      "real_name": "table_block",
+      "component_group_uuid": null,
+      "color": null,
+      "icon": null
+    },
+    {
       "name": "title_paragraph_block",
       "display_name": null,
       "schema": {


### PR DESCRIPTION
## What?
Add TableBlock to Storyblok. Storyblok has a pretty neat table component we can use. To solve the true/false values in order to show the available/not available icons I went for using `0` or `1`. We can of course extend the use if we want to use the table with text values, but that was nothing that Peter and Mange needed.


## Why?
Possibility to add compare tables inline on the page

Next step is to add a Modal component for this use case. Will gather some feedback from Mange and Peter after trying out this in staging.


https://user-images.githubusercontent.com/6661511/168300150-9c86d1e8-9aa5-4ef9-bf83-86167cfeaac4.mov


