### PR TITLE
GRW-1135 / Add compare Perils feature in Storyblok

### DIFF
--- a/src/blocks/PerilsBlock/PerilsBlock.tsx
+++ b/src/blocks/PerilsBlock/PerilsBlock.tsx
@@ -43,10 +43,13 @@ export const PerilsBlock: React.FC<PerilsBlockProps> = ({
     [insurance_types],
   )
 
-  let perils = usePerils(insuranceTypes, currentLocale.iso)
-  perils = compare_perils ? getPerilsComparison(perils) : perils
+  const perils = usePerils(insuranceTypes, currentLocale.iso)
+  const perilsGroup = useMemo(
+    () => (compare_perils ? getPerilsComparison(perils) : perils),
+    [compare_perils, perils],
+  )
 
-  const perilsCollections = perils.map(
+  const perilsCollections = perilsGroup.map(
     (perilItems: Peril[], i: number): PerilsCollection => ({
       id: insurance_types[i].value,
       label: insurance_types[i].label,

--- a/src/blocks/PerilsBlock/PerilsBlock.tsx
+++ b/src/blocks/PerilsBlock/PerilsBlock.tsx
@@ -14,6 +14,7 @@ import {
 import { GlobalStoryContainer } from 'storyblok/StoryContainer'
 import { Perils } from 'components/Perils'
 import { usePerils } from 'components/Perils/data/usePerils'
+import { getPerilsComparison } from 'components/Perils/Perils.helpers'
 
 export type ContractOption = {
   label: string
@@ -22,6 +23,7 @@ export type ContractOption = {
 
 export type PerilsBlockProps = BaseBlockProps & {
   insurance_types: ContractOption[]
+  compare_perils?: boolean
 }
 
 const ContentWrapper = styled(OriginalContentWrapper)`
@@ -33,6 +35,7 @@ export const PerilsBlock: React.FC<PerilsBlockProps> = ({
   index,
   size,
   insurance_types,
+  compare_perils,
 }) => {
   const { currentLocale } = useLocale()
   const insuranceTypes = useMemo(
@@ -40,7 +43,9 @@ export const PerilsBlock: React.FC<PerilsBlockProps> = ({
     [insurance_types],
   )
 
-  const perils = usePerils(insuranceTypes, currentLocale.iso)
+  let perils = usePerils(insuranceTypes, currentLocale.iso)
+  perils = compare_perils ? getPerilsComparison(perils) : perils
+
   const perilsCollections = perils.map(
     (perilItems: Peril[], i: number): PerilsCollection => ({
       id: insurance_types[i].value,
@@ -48,7 +53,6 @@ export const PerilsBlock: React.FC<PerilsBlockProps> = ({
       items: perilItems,
     }),
   )
-
   return (
     <GlobalStoryContainer>
       {({ globalStory }) => (

--- a/src/components/Perils/PerilItem/PerilItem.tsx
+++ b/src/components/Perils/PerilItem/PerilItem.tsx
@@ -62,6 +62,10 @@ const InnerContainer = styled.button<{
     background-color: ${colorsV3.gray100};
     border: 1px solid ${colorsV3.gray300};
     cursor: initial;
+
+    svg * {
+      fill: currentColor;
+    }
   }
 
   ${TABLET_BP_UP} {

--- a/src/components/Perils/Perils.helpers.ts
+++ b/src/components/Perils/Perils.helpers.ts
@@ -1,0 +1,23 @@
+import { Peril } from './types'
+
+export const isDisabledPeril = (perils: Peril[], peril: Peril) => {
+  return !perils.some((p) => p.title === peril.title)
+}
+
+export const getPerilsComparison = (perilsGroup: Peril[][]) => {
+  const uniquePerils = perilsGroup
+    .reduce((accumulated, perils) => accumulated.concat(perils), [])
+    .filter(
+      (peril, index: number, allPerils) =>
+        allPerils.findIndex((p) => p.title === peril.title) === index,
+    )
+
+  const perilsWithDisabledField = perilsGroup.map((perils) => {
+    return uniquePerils.map((peril) => ({
+      ...peril,
+      disabled: isDisabledPeril(perils, peril),
+    }))
+  })
+
+  return perilsWithDisabledField
+}

--- a/storyblok/components.json
+++ b/storyblok/components.json
@@ -2742,9 +2742,14 @@
           "default_value": "lg",
           "pos": 1
         },
+        "compare_perils": {
+          "type": "boolean",
+          "pos": 2,
+          "description": "Compare Perils between tabs"
+        },
         "insurance_types": {
           "type": "bloks",
-          "pos": 2,
+          "pos": 3,
           "use_uuid": true,
           "options": [
             {


### PR DESCRIPTION
## What?
Add possibility to show the differences between set of Perils. It accumulates the different Perils available in the set and shows the difference by a "disabled" look. 

I added a checkbox in Storyblok to enable the feature, will be used on the Car page.

Took inspo from @simonauner's comparison table implementation 😀 

## Why?
The initial plan was to add it as a field in PCMS, but since the release is approaching and it's uncertain if we can expect the feature to be implemented in PCMS before launch we could solve it on our side.


https://user-images.githubusercontent.com/6661511/169812100-0991b032-61ee-4de8-b7a6-3106a841bef6.mov

