### PR TITLE
GRW-1129 / Fix / Remove blue button border on iOS

### DIFF
--- a/src/components/Perils/PerilModal/PerilModal.tsx
+++ b/src/components/Perils/PerilModal/PerilModal.tsx
@@ -68,7 +68,7 @@ const DirectionButton = styled('button')`
   padding: 0;
   cursor: pointer;
   background: none;
-  border: 1px solid currentColor;
+  border: 1px solid ${colorsV3.gray900};
   border-radius: 0.5rem;
 
   svg {


### PR DESCRIPTION
## What?
Remove blue border on Perils modal button


## Why?
![IMG_2779](https://user-images.githubusercontent.com/6661511/170028757-c3cca167-dc1e-4c29-ac1b-994db84effdd.PNG)
