### PR TITLE
Remove user agent font-family on button and inputs

### DIFF
--- a/src/components/GlobalStyles.tsx
+++ b/src/components/GlobalStyles.tsx
@@ -83,6 +83,7 @@ export const globalStyles = css`
   input,
   button {
     font-size: inherit;
+    font-family: inherit;
   }
 `
 export const globalStylesStorybook = css`


### PR DESCRIPTION
## What?
Some buttons had `Arial` as font set by the user agent stylesheet. Make sure inputs and buttons inherit the Hedvig font

