### PR TITLE
Use v2 of content delivery API

### DIFF
--- a/src/server/sitemap.test.ts
+++ b/src/server/sitemap.test.ts
@@ -34,15 +34,15 @@ test('it stitches together a correct sitemap with cache miss', () => {
   })
   app.use(sitemapXml)
 
-  moxios.stubRequest(/^\/v1\/cdn\/links/, {
+  moxios.stubRequest(/^\/v2\/cdn\/links/, {
     status: 200,
     responseText: linksResponse,
   })
-  moxios.stubRequest(/^\/v1\/cdn\/stories\/se-en\/hello-world-26/, {
+  moxios.stubRequest(/^\/v2\/cdn\/stories\/se-en\/hello-world-26/, {
     status: 200,
     responseText: indexedStoryResponse,
   })
-  moxios.stubRequest(/^\/v1\/cdn\/stories\/se-en\/hello-world-27/, {
+  moxios.stubRequest(/^\/v2\/cdn\/stories\/se-en\/hello-world-27/, {
     status: 200,
     responseText: noindexedStoryResponse,
   })

--- a/src/server/utils/storyblok.ts
+++ b/src/server/utils/storyblok.ts
@@ -70,7 +70,7 @@ export const getGlobalStory = async (
   locale: string,
   bypassCache?: boolean,
 ): Promise<{ story: GlobalStory } | undefined> => {
-  const uri = encodeURI(`/v1/cdn/stories/${locale}/global`)
+  const uri = encodeURI(`/v2/cdn/stories/${locale}/global`)
   const axiosParams = {
     params: {
       token: config.storyblokApiToken,
@@ -91,7 +91,7 @@ export const getPublishedStoryFromSlug = async (
   path: string,
   bypassCache?: boolean,
 ): Promise<{ story: BodyStory }> => {
-  const uri = encodeURI(`/v1/cdn/stories${path}`)
+  const uri = encodeURI(`/v2/cdn/stories${path}`)
   const result = await cachedGet<{ story: BodyStory }>(
     uri,
     [
@@ -112,7 +112,7 @@ export const getPublishedStoryFromSlug = async (
 
 export const getDraftedStoryById = (id: string, cacheVersion: string) =>
   apiClient
-    .get<{ story: BodyStory }>(encodeURI(`/v1/cdn/stories/${id}`), {
+    .get<{ story: BodyStory }>(encodeURI(`/v2/cdn/stories/${id}`), {
       params: {
         token: config.storyblokApiToken,
         find_by: 'slug',
@@ -129,7 +129,7 @@ export const getDatasourceEntries = async (
   datasource: string,
   bypassCache?: boolean,
 ) => {
-  const uri = encodeURI(`/v1/cdn/datasource_entries?datasource=${datasource}`)
+  const uri = encodeURI(`/v2/cdn/datasource_entries?datasource=${datasource}`)
   const result = await cachedGet<{
     datasource_entries: DatasourceEntry[]
   }>(
@@ -164,7 +164,7 @@ export interface LinkResult {
   links: { [uuid: string]: Link }
 }
 export const getAllStoryblokLinks = () =>
-  apiClient.get<LinkResult>('/v1/cdn/links', {
+  apiClient.get<LinkResult>('/v2/cdn/links', {
     params: {
       token: config.storyblokApiToken,
       cv: calculateCacheVersionTimestamp(new Date()),


### PR DESCRIPTION
## What?
Use v2 of content delivery API


## Why?
Start using Storyblok v2 for market-web since there are no breaking changes to the API and we will set v2 as the default view in the CMS

