### PR TITLE
Make sure ImageTextBlock layout works with deferred image component

### DIFF
--- a/src/components/DeferredImage.tsx
+++ b/src/components/DeferredImage.tsx
@@ -1,6 +1,13 @@
 import styled from '@emotion/styled'
 import React from 'react'
 
+type Props = {
+  className?: string
+} & React.DetailedHTMLProps<
+  React.ImgHTMLAttributes<HTMLImageElement>,
+  HTMLImageElement
+>
+
 const getSizeFromURL = (url: string) => {
   const [, rawWidth, rawHeight] = url.match(/\/(\d+)x(\d+)\//) || []
 
@@ -14,12 +21,15 @@ const Img = styled.img({
   height: 'auto',
 })
 
-export const DeferredImage = ({
-  src,
-}: React.DetailedHTMLProps<
-  React.ImgHTMLAttributes<HTMLImageElement>,
-  HTMLImageElement
->) => {
+export const DeferredImage = ({ src, className, ...rest }: Props) => {
   const sizeProps = src ? getSizeFromURL(src) : ''
-  return <Img {...sizeProps} loading="lazy" src={src} />
+  return (
+    <Img
+      className={className}
+      loading="lazy"
+      src={src}
+      {...sizeProps}
+      {...rest}
+    />
+  )
 }


### PR DESCRIPTION
## What?
Pass along styles to `DeferredImage` component
<!-- What changes are made? If there are many changes, a list might be a good format. -->


## Why?
The layout in `ImageTextBlock` was not working after the last release so we had to roll back
<!-- Why are these changes made? -->
### Before
![image (3)](https://user-images.githubusercontent.com/6661511/206226317-c4530e75-15c2-4a10-ae62-0100f6f2ad50.png)

### After
<img width="1471" alt="Screenshot 2022-12-07 at 16 52 29" src="https://user-images.githubusercontent.com/6661511/206226567-e1010b9c-f000-4f00-b209-fc310f3d6f98.png">



**Ticket(s): []**
<!-- If there is a Jira issue, add the key (e.g. GRW-123) between the brackets, and a link to that issue will automatically be created. -->


<!-- If it makes sense, add screenshots and/or screen recordings below, with headlines and/or descriptions if needed. -->
<!--
## Screenshots / recordings 
-->

<!-- Finally, you can create a review app on Heroku to make it easier to review and/or get input from the design team before merging. -->
<!--
### [Review app]()
-->
