### PR TITLE
Load more articles on blog and category pages

### DIFF
--- a/src/blocks/ArticleListBlock/ArticleListBlock.tsx
+++ b/src/blocks/ArticleListBlock/ArticleListBlock.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled'
 import { useLocale } from 'context/LocaleContext'
 import { ContentWrapper, SectionWrapper } from 'components/blockHelpers'
 import { ArticleStory } from 'src/storyblok/StoryContainer'
+import { Button } from 'components/Button/Button'
 import { BaseBlockProps } from '../BaseBlockProps'
 import { ArticleTeaser } from './ArticleTeaser'
 
@@ -15,16 +16,21 @@ export const ArticleListBlock = ({ category }: ArticleListBlockProps) => {
   const {
     currentLocale: { label },
   } = useLocale()
-  const [articles, setArticles] = useState([])
+  const [articles, setArticles] = useState<ArticleStory[]>([])
+  const [page, setPage] = useState(1)
+  const [totalPages, setTotalPages] = useState(1)
+  const pageSize = 6
 
   useEffect(() => {
     const getArticles = async () => {
       try {
         const storyblokApi = getStoryblokApi()
-        const { data } = await storyblokApi.get(`cdn/stories/`, {
+        const { data, total } = await storyblokApi.get(`cdn/stories/`, {
           starts_with: `${label}`,
           content_type: 'article',
           resolve_relations: 'article.categories',
+          per_page: pageSize,
+          page: page,
           ...(category && {
             filter_query: {
               categories: {
@@ -34,13 +40,21 @@ export const ArticleListBlock = ({ category }: ArticleListBlockProps) => {
           }),
         })
 
-        setArticles(data.stories)
+        const totalPages = Math.ceil(total / pageSize)
+        setTotalPages(totalPages)
+        setArticles((previousArticles) => {
+          return [...previousArticles, ...data.stories]
+        })
       } catch (error) {
         setArticles([])
       }
     }
     getArticles()
-  }, [label, category])
+  }, [label, category, page])
+
+  const handleClick = () => {
+    setPage((prev) => prev + 1)
+  }
 
   return (
     <SectionWrapper brandPivot>
@@ -52,13 +66,23 @@ export const ArticleListBlock = ({ category }: ArticleListBlockProps) => {
             </Link>
           ))}
         </Grid>
+        {page < totalPages && (
+          // TODO: Translate button label
+          <Button onClick={handleClick}>Fler nyheter</Button>
+        )}
       </Wrapper>
     </SectionWrapper>
   )
 }
 
 const Wrapper = styled(ContentWrapper)`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4rem;
   max-width: 84rem;
+  min-height: 60vh;
+  margin-inline: auto;
 `
 
 const Grid = styled.div`


### PR DESCRIPTION
<!-- 
To link the branch/PR to a Jira issue either
1. (preferred) add the issue key to the name of your branch (e.g. GRW-123/fix/some-annoying-bug)
2. prefix your PR title with it

Also, if applicable, include whether this is a Fix, Feature or Chore.

Example PR title: GRW-123 / Feature / Awesome new thing
-->

## What?
Use Storybloks pagination to load more articles https://www.storyblok.com/docs/api/content-delivery/v2#topics/pagination

(A total of 8 articles in this example)

https://user-images.githubusercontent.com/6661511/213403461-68ecd515-6535-4997-96bb-7c827c1a78af.mov

Figma design: https://www.figma.com/file/uAdk5vm5XMPvXHjuQJb9vr/Blog%2FPress-site?node-id=96%3A1524&t=qTk2J1UJXVwWEw7t-1

Next steps:
- Add button label translation to global story
- Add some kind of loading state

## Why?
A user should be able to see older articles. 

<!-- Why are these changes made? -->



**Ticket(s): []**
<!-- If there is a Jira issue, add the key (e.g. GRW-123) between the brackets, and a link to that issue will automatically be created. -->


<!-- If it makes sense, add screenshots and/or screen recordings below, with headlines and/or descriptions if needed. -->
<!--
## Screenshots / recordings 
-->

<!-- Finally, you can create a review app on Heroku to make it easier to review and/or get input from the design team before merging. -->
<!--
### [Review app]()
-->
